### PR TITLE
#43 - Add support for Gamma

### DIFF
--- a/dkpro-statistics-agreement/pom.xml
+++ b/dkpro-statistics-agreement/pom.xml
@@ -51,10 +51,19 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.ojalgo</groupId>
+      <artifactId>ojalgo</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/aligning/GammaAgreement.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/aligning/GammaAgreement.java
@@ -1,0 +1,463 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Ported from the pygamma-agreement project:
+ * https://github.com/bootphon/pygamma-agreement - version 0.5.9, commit 44587ef.
+ * Original file: pygamma_agreement/continuum.py (Continuum.compute_gamma and GammaResults).
+ * Original authors: Rachid Riad, Hadrien Titeux, Léopold Favre.
+ *
+ * The original code is distributed under the MIT license, reproduced verbatim below:
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020-2021 CoML
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Paper: Mathet, Widlöcher, and Métivier (2015), "The Unified and Holistic Method
+ * Gamma for Inter-Annotator Agreement Measure and Alignment"
+ * (https://aclanthology.org/J15-3003.pdf).
+ */
+package org.dkpro.statistics.agreement.aligning;
+
+import static java.lang.Math.ceil;
+import static java.lang.Math.pow;
+
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+
+import org.apache.commons.math3.random.RandomGenerator;
+import org.apache.commons.math3.random.Well19937c;
+import org.apache.commons.math3.stat.descriptive.moment.Mean;
+import org.apache.commons.math3.stat.descriptive.moment.StandardDeviation;
+import org.dkpro.statistics.agreement.DisagreementMeasure;
+import org.dkpro.statistics.agreement.InsufficientDataException;
+import org.dkpro.statistics.agreement.aligning.alignment.BestAlignmentSolver;
+import org.dkpro.statistics.agreement.aligning.alignment.BestAlignmentSolver.BestAlignment;
+import org.dkpro.statistics.agreement.aligning.data.AnnotationSet;
+import org.dkpro.statistics.agreement.aligning.disorder.IDisorderSampler;
+import org.dkpro.statistics.agreement.aligning.disorder.IGammaDisorderSamplerFactory;
+import org.dkpro.statistics.agreement.aligning.dissimilarity.AbstractDissimilarity;
+import org.dkpro.statistics.agreement.aligning.dissimilarity.CombinedCategoricalDissimilarity;
+import org.dkpro.statistics.agreement.aligning.dissimilarity.IDissimilarity;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation of the Mathet et al. (2015) gamma (&gamma;) inter-annotator agreement measure for a
+ * continuum of timed intervals, ported from pygamma-agreement's
+ * {@code Continuum.compute_gamma}/{@code GammaResults}.
+ * <p>
+ * The <b>observed disagreement</b> is the disorder of the best (minimal-disorder) alignment of the
+ * continuum, computed exactly via {@link BestAlignmentSolver}. The <b>expected disagreement</b> is the
+ * mean best-alignment disorder over a batch of random continua drawn from an injected
+ * {@link IDisorderSampler}. Gamma is then {@code 1 - observed / expected}.
+ * <p>
+ * References:
+ * <ul>
+ * <li>Mathet, Widlöcher, Métivier (2015): <i>The Unified and Holistic Method Gamma (&gamma;) for
+ * Inter-Annotator Agreement Measure and Alignment.</i> Computational Linguistics 41(3),
+ * <a href="https://aclanthology.org/J15-3003.pdf">https://aclanthology.org/J15-3003.pdf</a>.</li>
+ * <li>Titeux &amp; Riccardi (2021): <i>pygamma-agreement</i>,
+ * <a href="https://github.com/bootphon/pygamma-agreement">https://github.com/bootphon/pygamma-agreement</a>.</li>
+ * </ul>
+ * <p>
+ * Corresponds to the Python {@code Continuum.compute_gamma} + {@code GammaResults.gamma}. Deviations
+ * from the original:
+ * <ul>
+ * <li>Units carry {@code long} offsets and everything is computed in {@code double} instead of
+ * pygamma's {@code float32} (expect ~1e-5 relative divergence against reference values).</li>
+ * <li>The expected-disorder procedure is a faithful port of pygamma's <b>one-shot top-up</b>: draw
+ * {@code numberOfSamples} samples, optionally re-estimate the required count once from their
+ * coefficient of variation and draw a single top-up batch. This deliberately differs from
+ * {@link TextGammaAgreement#calculateExpectedDisagreement}, which loops until the estimate
+ * stabilizes.</li>
+ * <li>Gamma is <b>not clamped</b> and may be negative, exactly as in pygamma.</li>
+ * </ul>
+ * <p>
+ * <b>Validation scope.</b> This port is cross-validated against pygamma-agreement 0.5.9 only for the
+ * default {@code deltaEmpty == 1.0} (the value used by both the pygamma library and its CLI). For that
+ * value the observed disorder, candidate pruning, and best-alignment disorder match the reference to
+ * within the {@code float32}-vs-{@code double} floor (~1e-5 relative). It is <b>not</b> validated for
+ * other {@code deltaEmpty} values, and it will deliberately <i>not</i> reproduce pygamma 0.5.9's output
+ * there, because pygamma 0.5.9 has a bug for non-default {@code deltaEmpty}:
+ * {@code AbstractDissimilarity.__init__} compiles and caches the {@code njit} {@code d_mat} closure
+ * immediately, and {@code CombinedCategoricalDissimilarity} then reassigns
+ * {@code cat_dissim.delta_empty} <i>without</i> recompiling that closure. As a result pygamma's
+ * best-alignment/pruning path (which uses the cached {@code d_mat}) scores categorical disagreement with
+ * the stale {@code delta_empty = 1.0}, while its public {@code d()} method uses the requested value. This
+ * makes pygamma internally inconsistent for {@code deltaEmpty != 1.0}. This implementation applies
+ * {@code deltaEmpty} consistently to both the positional and categorical terms (so it is arguably more
+ * correct), and consequently diverges from pygamma 0.5.9 for those values.
+ *
+ * @see <a href="https://github.com/bootphon/pygamma-agreement">pygamma-agreement</a>
+ * @see <a href="https://aclanthology.org/J15-3003.pdf">Mathet et al. 2015</a>
+ */
+public class GammaAgreement
+    extends DisagreementMeasure
+    implements IAligningAgreementMeasure
+{
+    private static final Logger LOG = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+    /** Confidence factor for a 95% confidence interval, hardcoded in pygamma. */
+    private static final double CONFIDENCE_95 = 1.96;
+
+    private final AnnotationSet annotationSet;
+    private final IDissimilarity dissimilarity;
+    private final double deltaEmpty;
+    private final IDisorderSampler sampler;
+    private final int numberOfSamples;
+    private final Double precisionLevel;
+    private final RandomGenerator randomGenerator;
+
+    private BestAlignment bestAlignment;
+    private int expectedDisagreementSampleCount = -1;
+
+    private GammaAgreement(Builder builder)
+    {
+        if (builder.annotationSet == null) {
+            throw new IllegalArgumentException("An annotation set (continuum) must be given");
+        }
+
+        if (builder.annotationSet.getRaterCount() < 2) {
+            throw new IllegalArgumentException(
+                    "The continuum must contain at least two raters, but contains "
+                            + builder.annotationSet.getRaterCount() + ".");
+        }
+
+        if (builder.numberOfSamples < 1) {
+            throw new IllegalArgumentException(
+                    "The number of samples must be positive, but was " + builder.numberOfSamples
+                            + ".");
+        }
+
+        if (builder.precisionLevel != null
+                && !(builder.precisionLevel > 0.0 && builder.precisionLevel < 1.0)) {
+            throw new IllegalArgumentException(
+                    "The precision level must be null or in the open interval (0, 1), but was "
+                            + builder.precisionLevel + ".");
+        }
+
+        annotationSet = builder.annotationSet;
+        dissimilarity = builder.dissimilarity;
+        deltaEmpty = builder.deltaEmpty;
+        numberOfSamples = builder.numberOfSamples;
+        precisionLevel = builder.precisionLevel;
+
+        // Resolve the source of randomness before the sampler is created below, so a sampler created
+        // through the factory can pick it up via getRandomGenerator(). When no generator (or seed) is
+        // configured we fall back to a fresh, time-seeded generator (mirrors TextGammaAgreement).
+        randomGenerator = builder.randomGenerator != null ? builder.randomGenerator
+                : new Well19937c();
+
+        // The sampler is optional: it is only required by calculateExpectedDisagreement() /
+        // calculateAgreement(). A caller interested solely in the observed disorder need not supply
+        // one. When neither a sampler nor a factory is given, the sampler stays null and the
+        // expected-disorder path throws lazily (see requireSampler()).
+        if (builder.sampler != null) {
+            sampler = builder.sampler;
+        }
+        else if (builder.samplerFactory != null) {
+            sampler = builder.samplerFactory.create(this);
+        }
+        else {
+            sampler = null;
+        }
+    }
+
+    public AnnotationSet getAnnotationSet()
+    {
+        return annotationSet;
+    }
+
+    public IDissimilarity getDissimilarity()
+    {
+        return dissimilarity;
+    }
+
+    public double getDeltaEmpty()
+    {
+        return deltaEmpty;
+    }
+
+    /**
+     * @return the source of randomness used by the chance model. Samplers should draw all their
+     *         randomness from this generator so that a seed configured via {@link Builder#withSeed}
+     *         (or {@link Builder#withRandomGenerator}) makes the measurement reproducible.
+     */
+    public RandomGenerator getRandomGenerator()
+    {
+        return randomGenerator;
+    }
+
+    /**
+     * @return the cached best alignment computed for the observed disorder. Mirrors
+     *         {@code GammaResults.best_alignment}. Computed lazily on first access.
+     */
+    public BestAlignment getBestAlignment()
+    {
+        if (bestAlignment == null) {
+            bestAlignment = BestAlignmentSolver.solve(annotationSet, dissimilarity, deltaEmpty);
+        }
+
+        return bestAlignment;
+    }
+
+    /**
+     * @return the number of samples that the most recent {@link #calculateExpectedDisagreement()}
+     *         call actually drew (i.e. {@code numberOfSamples} plus any one-shot top-up), or
+     *         {@code -1} if the expected disagreement has not been computed yet.
+     */
+    public int getExpectedDisagreementSampleCount()
+    {
+        return expectedDisagreementSampleCount;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @throws InsufficientDataException
+     *             if the expected disorder is zero while the observed disorder is positive: there is
+     *             no chance baseline to correct against, so gamma would be an undefined division by
+     *             zero. Mirrors the spirit of {@link TextGammaAgreement}'s zero-expected handling.
+     */
+    @Override
+    public double calculateAgreement()
+    {
+        var observedDisorder = calculateObservedDisagreement();
+
+        // pygamma GammaResults.gamma special case: an observed disorder of exactly zero yields gamma
+        // == 1 without dividing by the expected disorder (and without even drawing any samples).
+        if (observedDisorder == 0.0) {
+            return 1.0;
+        }
+
+        var expectedDisorder = calculateExpectedDisagreement();
+
+        LOG.trace("Disorder -- observed: {} -- expected: {}", observedDisorder, expectedDisorder);
+
+        if (expectedDisorder == 0.0) {
+            throw new InsufficientDataException(
+                    "Expected disorder is zero while observed disorder is positive: the chance model "
+                            + "could not introduce any disorder, so there is no chance baseline to "
+                            + "correct against.");
+        }
+
+        // Deliberately NOT clamped: gamma may be negative when the observed disorder exceeds the
+        // expected disorder. Mirrors pygamma GammaResults.gamma.
+        return 1.0 - (observedDisorder / expectedDisorder);
+    }
+
+    @Override
+    public double calculateObservedDisagreement()
+    {
+        return getBestAlignment().disorder();
+    }
+
+    @Override
+    public double calculateExpectedDisagreement()
+    {
+        var s = requireSampler();
+
+        // Exact port of pygamma continuum.py:compute_gamma. Draw the initial batch.
+        var disorders = new ArrayList<Double>(numberOfSamples);
+        for (int i = 0; i < numberOfSamples; i++) {
+            disorders.add(s.sampleDisorder());
+        }
+
+        // Optional one-shot re-estimation (single top-up batch, NOT a re-checking loop). When
+        // precisionLevel is null (the pygamma library default) exactly numberOfSamples samples are
+        // used, with no variation test.
+        if (precisionLevel != null) {
+            var mean = new Mean();
+            // ddof=0 population standard deviation, matching numpy's np.std default. Commons-math's
+            // StandardDeviation defaults to the bias-corrected (sample, ddof=1) variant, so we must
+            // explicitly disable bias correction here.
+            var populationStd = new StandardDeviation(false);
+            for (var disorder : disorders) {
+                mean.increment(disorder);
+                populationStd.increment(disorder);
+            }
+
+            double variationCoeff = populationStd.getResult() / mean.getResult();
+            long requiredSamples = (long) ceil(
+                    pow(variationCoeff * CONFIDENCE_95 / precisionLevel, 2));
+
+            if (requiredSamples > numberOfSamples) {
+                LOG.info("Computing second batch of {} samples because variation was too high.",
+                        requiredSamples - numberOfSamples);
+                for (long i = numberOfSamples; i < requiredSamples; i++) {
+                    disorders.add(s.sampleDisorder());
+                }
+            }
+        }
+
+        expectedDisagreementSampleCount = disorders.size();
+
+        var mean = new Mean();
+        for (var disorder : disorders) {
+            mean.increment(disorder);
+        }
+
+        return mean.getResult();
+    }
+
+    private IDisorderSampler requireSampler()
+    {
+        if (sampler == null) {
+            throw new IllegalStateException(
+                    "No disorder sampler was configured. A sampler (or sampler factory) is required "
+                            + "to compute the expected disagreement / agreement, but not for the "
+                            + "observed disagreement.");
+        }
+
+        return sampler;
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+        private AnnotationSet annotationSet;
+        private IDissimilarity dissimilarity = new CombinedCategoricalDissimilarity();
+        private double deltaEmpty = 1.0;
+        private IDisorderSampler sampler;
+        private IGammaDisorderSamplerFactory samplerFactory;
+        private int numberOfSamples = 30;
+        private Double precisionLevel = null;
+        private RandomGenerator randomGenerator;
+
+        private Builder()
+        {
+        }
+
+        /**
+         * Sets the continuum whose agreement is measured.
+         */
+        public Builder withAnnotationSet(AnnotationSet aAnnotationSet)
+        {
+            annotationSet = aAnnotationSet;
+            return this;
+        }
+
+        /**
+         * Sets the dissimilarity together with an explicit empty-unit cost.
+         */
+        public Builder withDissimilarity(IDissimilarity aDissimilarity, double aDeltaEmpty)
+        {
+            dissimilarity = aDissimilarity;
+            deltaEmpty = aDeltaEmpty;
+            return this;
+        }
+
+        /**
+         * Sets the dissimilarity and derives the empty-unit cost from it (via
+         * {@link AbstractDissimilarity#getDeltaEmpty()}).
+         */
+        public Builder withDissimilarity(AbstractDissimilarity aDissimilarity)
+        {
+            dissimilarity = aDissimilarity;
+            deltaEmpty = aDissimilarity.getDeltaEmpty();
+            return this;
+        }
+
+        /**
+         * Sets the chance model used to estimate the expected disorder. A sampler (or a
+         * {@link IGammaDisorderSamplerFactory factory}) is <b>required</b>: there is no default, and
+         * computing gamma without one throws.
+         *
+         * @see org.dkpro.statistics.agreement.aligning.disorder.StatisticalContinuumDisorderSampler
+         *      the statistical resampling sampler mirroring pygamma's default
+         */
+        public Builder withDisorderSampler(IDisorderSampler aSampler)
+        {
+            sampler = aSampler;
+            samplerFactory = null;
+            return this;
+        }
+
+        public Builder withDisorderSampler(IGammaDisorderSamplerFactory aSamplerFactory)
+        {
+            samplerFactory = aSamplerFactory;
+            sampler = null;
+            return this;
+        }
+
+        /**
+         * Number of random continua sampled to estimate the expected disorder. Defaults to 30
+         * (pygamma's {@code n_samples}).
+         */
+        public Builder withNumberOfSamples(int aNumberOfSamples)
+        {
+            numberOfSamples = aNumberOfSamples;
+            return this;
+        }
+
+        /**
+         * Target error percentage of the gamma estimation, in the open interval (0, 1), or
+         * {@code null} for none. When {@code null} (the pygamma library default) exactly
+         * {@link #withNumberOfSamples(int) numberOfSamples} samples are drawn with no top-up. When
+         * set, a single top-up batch may be drawn once (see
+         * {@link GammaAgreement#calculateExpectedDisagreement()}).
+         */
+        public Builder withPrecisionLevel(Double aPrecisionLevel)
+        {
+            precisionLevel = aPrecisionLevel;
+            return this;
+        }
+
+        /**
+         * Seeds the chance model so that the measurement is reproducible. Convenience shortcut for
+         * {@link #withRandomGenerator} with a {@link Well19937c} seeded with {@code aSeed}.
+         */
+        public Builder withSeed(long aSeed)
+        {
+            randomGenerator = new Well19937c(aSeed);
+            return this;
+        }
+
+        /**
+         * Supplies the source of randomness for the chance model. See {@link #withSeed} for the
+         * effect on reproducibility.
+         */
+        public Builder withRandomGenerator(RandomGenerator aRandomGenerator)
+        {
+            randomGenerator = aRandomGenerator;
+            return this;
+        }
+
+        public GammaAgreement build()
+        {
+            return new GammaAgreement(this);
+        }
+    }
+}

--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/aligning/alignment/BestAlignmentSolver.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/aligning/alignment/BestAlignmentSolver.java
@@ -1,0 +1,336 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Ported from the pygamma-agreement project:
+ * https://github.com/bootphon/pygamma-agreement - version 0.5.9, commit 44587ef.
+ * Original files: pygamma_agreement/dissimilarity.py (_get_all_valid_alignments),
+ * pygamma_agreement/continuum.py (get_best_alignment) and
+ * pygamma_agreement/numba_utils.py (build_A, iter_tuples).
+ * Original authors: Rachid Riad, Hadrien Titeux, Léopold Favre.
+ *
+ * The original code is distributed under the MIT license, reproduced verbatim below:
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020-2021 CoML
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Paper: Mathet, Widlöcher, and Métivier (2015), "The Unified and Holistic Method
+ * Gamma for Inter-Annotator Agreement Measure and Alignment"
+ * (https://aclanthology.org/J15-3003.pdf).
+ */
+package org.dkpro.statistics.agreement.aligning.alignment;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.dkpro.statistics.agreement.aligning.AlignableAnnotationUnit;
+import org.dkpro.statistics.agreement.aligning.data.AnnotationSet;
+import org.dkpro.statistics.agreement.aligning.data.Rater;
+import org.dkpro.statistics.agreement.aligning.dissimilarity.AbstractDissimilarity;
+import org.dkpro.statistics.agreement.aligning.dissimilarity.IDissimilarity;
+import org.ojalgo.optimisation.Expression;
+import org.ojalgo.optimisation.ExpressionsBasedModel;
+import org.ojalgo.optimisation.Optimisation;
+import org.ojalgo.optimisation.Variable;
+
+/**
+ * Computes the exact best (minimal-disorder) alignment of a continuum, mirroring pygamma-agreement.
+ * <p>
+ * The computation has two stages:
+ * <ol>
+ * <li><b>Candidate generation and pruning</b> - a port of
+ * {@code dissimilarity.py:_get_all_valid_alignments}. It enumerates the cartesian product over the
+ * units of each rater (each extended by an "empty" unit) and keeps a candidate unitary alignment iff
+ * its raw pair-sum disorder is at most {@code C(n,2) * deltaEmpty * n} (the criterion from Mathet et
+ * al. 2015, section 5.1.1). The all-empty tuple is discarded. Kept disorders are divided by
+ * {@code C(n,2)}.</li>
+ * <li><b>Exact best-alignment computation</b> - a port of {@code continuum.py:get_best_alignment}
+ * (with the constraint matrix of {@code numba_utils.py:build_A}). A binary integer linear program is
+ * solved with ojAlgo: one binary variable per candidate, one equality constraint per (rater, unit)
+ * requiring that unit to appear in exactly one chosen candidate, minimizing the total candidate
+ * disorder.</li>
+ * </ol>
+ * <p>
+ * Deviations from the original: units carry {@code long} offsets and computations are performed in
+ * {@code double} rather than pygamma's {@code float32}; the ILP is solved with ojAlgo (pure-Java MIP)
+ * instead of cvxpy/CBC/GLPK; candidates are enumerated lazily with an odometer instead of numba's
+ * {@code iter_tuples}; the all-empty tuple is skipped explicitly rather than by dropping the last
+ * enumerated element. Only the optimal disorder <em>value</em> is guaranteed to match the reference -
+ * the concrete chosen alignment may differ when there are ties.
+ *
+ * @see <a href="https://github.com/bootphon/pygamma-agreement">pygamma-agreement</a>
+ * @see <a href="https://aclanthology.org/J15-3003.pdf">Mathet et al. 2015</a>
+ */
+public final class BestAlignmentSolver
+{
+    /**
+     * Upper bound on the size of the cartesian product {@code Π (n_i + 1)} that the exact solver is
+     * willing to enumerate. Beyond this the continuum is rejected as too large.
+     */
+    public static final long MAX_PRODUCT_SIZE = 50_000_000L;
+
+    private BestAlignmentSolver()
+    {
+        // utility class
+    }
+
+    /**
+     * Result of an exact best-alignment computation.
+     *
+     * @param alignment
+     *            the chosen best alignment (a valid partition of the annotation set).
+     * @param disorder
+     *            the observed disorder, i.e. the sum of the chosen candidate disorders divided by the
+     *            continuum's average number of annotations per rater. This equals
+     *            {@code alignment.getDisorder(dissimilarity)} up to floating-point error.
+     */
+    public record BestAlignment(Alignment alignment, double disorder)
+    {
+    }
+
+    /**
+     * Convenience overload deriving {@code deltaEmpty} from the given dissimilarity, which must be an
+     * {@link AbstractDissimilarity}.
+     */
+    public static BestAlignment solve(AnnotationSet aAnnotationSet, AbstractDissimilarity aDissimilarity)
+    {
+        return solve(aAnnotationSet, aDissimilarity, aDissimilarity.getDeltaEmpty());
+    }
+
+    /**
+     * Computes the exact best alignment of the given annotation set.
+     *
+     * @param aAnnotationSet
+     *            the continuum; must contain at least two raters.
+     * @param aDissimilarity
+     *            the dissimilarity used to score unit-to-unit disorder.
+     * @param aDeltaEmpty
+     *            the cost of pairing a unit with the empty unit.
+     * @return the best alignment and its disorder.
+     * @throws IllegalArgumentException
+     *             if there are fewer than two raters or the continuum is too large for the exact
+     *             solver.
+     * @throws IllegalStateException
+     *             if the ILP solver does not reach an optimal solution.
+     */
+    public static BestAlignment solve(AnnotationSet aAnnotationSet, IDissimilarity aDissimilarity,
+            double aDeltaEmpty)
+    {
+        var candidates = generateCandidates(aAnnotationSet, aDissimilarity, aDeltaEmpty);
+        return buildBestAlignment(aAnnotationSet, candidates);
+    }
+
+    /**
+     * Holds the pruned candidate unitary alignments for a continuum. Each candidate is a tuple of unit
+     * indices (one per rater, in the annotation set's canonical rater order); an index equal to
+     * {@code sizes[i]} denotes the empty unit for rater {@code i}. The parallel {@code disorders} list
+     * holds each candidate's unitary-alignment disorder (raw pair-sum divided by {@code C(n,2)}).
+     */
+    record CandidateSet(List<Rater> raters, List<List<AlignableAnnotationUnit>> unitsPerRater,
+            int[] sizes, List<int[]> tuples, List<Double> disorders)
+    {
+    }
+
+    /**
+     * Generates and prunes the candidate unitary alignments, mirroring
+     * {@code dissimilarity.py:_get_all_valid_alignments}.
+     */
+    static CandidateSet generateCandidates(AnnotationSet aAnnotationSet,
+            IDissimilarity aDissimilarity, double aDeltaEmpty)
+    {
+        var raters = new ArrayList<Rater>(aAnnotationSet.getRaters());
+        int n = raters.size();
+        if (n < 2) {
+            throw new IllegalArgumentException(
+                    "The best alignment cannot be computed with fewer than two raters.");
+        }
+
+        // Units per rater, in the annotation set's canonical order.
+        List<List<AlignableAnnotationUnit>> unitsPerRater = new ArrayList<>(n);
+        int[] sizes = new int[n];
+        for (int i = 0; i < n; i++) {
+            var units = aAnnotationSet.getUnitsWithRater(raters.get(i));
+            unitsPerRater.add(units);
+            sizes[i] = units.size();
+        }
+
+        // Guard against a combinatorial explosion: Π (n_i + 1).
+        long product = 1;
+        for (int i = 0; i < n; i++) {
+            product *= (sizes[i] + 1L);
+            if (product > MAX_PRODUCT_SIZE) {
+                throw new IllegalArgumentException("The continuum is too large for the exact solver: "
+                        + "the candidate cartesian product exceeds " + MAX_PRODUCT_SIZE
+                        + " tuples. Consider reducing the number of units per rater.");
+            }
+        }
+
+        long c2n = (long) n * (n - 1) / 2;
+        double criterion = c2n * aDeltaEmpty * n;
+
+        // Precompute, for each rater pair (a > b), the (sizes[a]+1) x (sizes[b]+1) dissimilarity
+        // matrix. The last row/column (index sizes[x]) holds the empty-unit cost deltaEmpty.
+        // Mirrors the precomputation block of _get_all_valid_alignments.
+        double[][][][] precomp = new double[n][][][];
+        for (int a = 0; a < n; a++) {
+            precomp[a] = new double[a][][];
+            var unitsA = unitsPerRater.get(a);
+            for (int b = 0; b < a; b++) {
+                var unitsB = unitsPerRater.get(b);
+                double[][] matrix = new double[sizes[a] + 1][sizes[b] + 1];
+                for (int ia = 0; ia < sizes[a]; ia++) {
+                    for (int ib = 0; ib < sizes[b]; ib++) {
+                        matrix[ia][ib] = aDissimilarity.dissimilarity(unitsA.get(ia), unitsB.get(ib));
+                    }
+                }
+                for (int ib = 0; ib <= sizes[b]; ib++) {
+                    matrix[sizes[a]][ib] = aDeltaEmpty;
+                }
+                for (int ia = 0; ia <= sizes[a]; ia++) {
+                    matrix[ia][sizes[b]] = aDeltaEmpty;
+                }
+                precomp[a][b] = matrix;
+            }
+        }
+
+        // Lazily enumerate the cartesian product (odometer over sizes[i]+1), keeping valid
+        // candidates. Index sizes[i] denotes the empty unit for rater i.
+        List<int[]> candidateTuples = new ArrayList<>();
+        List<Double> candidateDisorders = new ArrayList<>();
+        int[] tuple = new int[n];
+        boolean done = false;
+        while (!done) {
+            double rawSum = 0;
+            for (int a = 0; a < n; a++) {
+                for (int b = 0; b < a; b++) {
+                    rawSum += precomp[a][b][tuple[a]][tuple[b]];
+                }
+            }
+
+            boolean allEmpty = true;
+            for (int i = 0; i < n; i++) {
+                if (tuple[i] != sizes[i]) {
+                    allEmpty = false;
+                    break;
+                }
+            }
+
+            if (!allEmpty && rawSum <= criterion) {
+                candidateTuples.add(tuple.clone());
+                candidateDisorders.add(rawSum / c2n);
+            }
+
+            // Increment the odometer (little-endian), exactly like iter_tuples.
+            done = true;
+            for (int i = 0; i < n; i++) {
+                tuple[i]++;
+                if (tuple[i] <= sizes[i]) {
+                    done = false;
+                    break;
+                }
+                tuple[i] = 0;
+            }
+        }
+
+        return new CandidateSet(raters, unitsPerRater, sizes, candidateTuples, candidateDisorders);
+    }
+
+    private static BestAlignment buildBestAlignment(AnnotationSet aAnnotationSet,
+            CandidateSet aCandidates)
+    {
+        List<Rater> raters = aCandidates.raters();
+        List<List<AlignableAnnotationUnit>> unitsPerRater = aCandidates.unitsPerRater();
+        int[] sizes = aCandidates.sizes();
+        List<int[]> candidateTuples = aCandidates.tuples();
+        List<Double> candidateDisorders = aCandidates.disorders();
+        int n = raters.size();
+        int numCandidates = candidateTuples.size();
+
+        var model = new ExpressionsBasedModel();
+
+        Variable[] vars = new Variable[numCandidates];
+        for (int p = 0; p < numCandidates; p++) {
+            vars[p] = model.addVariable("x" + p).binary().weight(candidateDisorders.get(p));
+        }
+
+        // One equality constraint per (rater, unit): the unit must appear in exactly one chosen
+        // candidate. Mirrors the constraint matrix A of build_A with A * x == 1.
+        var constraints = new Expression[n][];
+        for (int i = 0; i < n; i++) {
+            constraints[i] = new Expression[sizes[i]];
+            for (int j = 0; j < sizes[i]; j++) {
+                constraints[i][j] = model.addExpression("c_" + i + "_" + j).level(1.0);
+            }
+        }
+        for (int p = 0; p < numCandidates; p++) {
+            int[] t = candidateTuples.get(p);
+            for (int i = 0; i < n; i++) {
+                int unitId = t[i];
+                if (unitId != sizes[i]) { // non-empty unit
+                    constraints[i][unitId].set(vars[p], 1.0);
+                }
+            }
+        }
+
+        Optimisation.Result result = model.minimise();
+        if (!result.getState().isOptimal()) {
+            throw new IllegalStateException(
+                    "The linear solver could not find an optimal alignment (state: "
+                            + result.getState() + ").");
+        }
+
+        Set<UnitaryAlignment> unitaryAlignments = new HashSet<>();
+        double sumDisorder = 0;
+        var raterSet = aAnnotationSet.getRaters();
+        for (int p = 0; p < numCandidates; p++) {
+            // cvxpy compares against 0.9 because the solver may return values like 1.0 or ~1e-14.
+            if (result.doubleValue(p) <= 0.9) {
+                continue;
+            }
+
+            int[] t = candidateTuples.get(p);
+            var units = new ArrayList<AlignableAnnotationUnit>();
+            for (int i = 0; i < n; i++) {
+                if (t[i] != sizes[i]) { // non-empty unit
+                    units.add(unitsPerRater.get(i).get(t[i]));
+                }
+            }
+            unitaryAlignments.add(new UnitaryAlignment(units, raterSet));
+            sumDisorder += candidateDisorders.get(p);
+        }
+
+        var alignment = new Alignment(unitaryAlignments, aAnnotationSet);
+        double disorder = sumDisorder / aAnnotationSet.getAverageNumberOfAnnotations();
+        return new BestAlignment(alignment, disorder);
+    }
+}

--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/aligning/disorder/IGammaDisorderSamplerFactory.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/aligning/disorder/IGammaDisorderSamplerFactory.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Technische Universität Darmstadt under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The Technische Universität Darmstadt
+ * licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.statistics.agreement.aligning.disorder;
+
+import org.dkpro.statistics.agreement.aligning.GammaAgreement;
+
+/**
+ * Factory for a {@link IDisorderSampler} bound to a {@link GammaAgreement}. This is the gamma-specific
+ * analogue of {@link IDisorderSamplerFactory} (which is typed to {@code TextGammaAgreement} and hence
+ * cannot be reused here). It lets a sampler pick up the measure's continuum and source of randomness
+ * (via {@link GammaAgreement#getAnnotationSet()} and {@link GammaAgreement#getRandomGenerator()}) at
+ * build time - this is how {@link StatisticalContinuumDisorderSampler} is wired in.
+ */
+@FunctionalInterface
+public interface IGammaDisorderSamplerFactory
+{
+    IDisorderSampler create(GammaAgreement aMeasure);
+}

--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/aligning/disorder/StatisticalContinuumDisorderSampler.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/aligning/disorder/StatisticalContinuumDisorderSampler.java
@@ -1,0 +1,399 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Ported from the pygamma-agreement project:
+ * https://github.com/bootphon/pygamma-agreement - version 0.5.9, commit 44587ef.
+ * Original file: pygamma_agreement/sampler.py (class StatisticalContinuumSampler),
+ * fused with the sample-disorder job wiring of pygamma_agreement/continuum.py
+ * (Continuum.compute_gamma, which draws each sample via a sampler and takes its
+ * best-alignment disorder).
+ * Original authors: Rachid Riad, Hadrien Titeux, Léopold Favre.
+ *
+ * The original code is distributed under the MIT license, reproduced verbatim below:
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020-2021 CoML
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Paper: Mathet, Widlöcher, and Métivier (2015), "The Unified and Holistic Method
+ * Gamma for Inter-Annotator Agreement Measure and Alignment"
+ * (https://aclanthology.org/J15-3003.pdf).
+ */
+package org.dkpro.statistics.agreement.aligning.disorder;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.apache.commons.math3.random.RandomGenerator;
+import org.dkpro.statistics.agreement.aligning.AlignableAnnotationUnit;
+import org.dkpro.statistics.agreement.aligning.GammaAgreement;
+import org.dkpro.statistics.agreement.aligning.alignment.BestAlignmentSolver;
+import org.dkpro.statistics.agreement.aligning.data.AnnotationSet;
+import org.dkpro.statistics.agreement.aligning.data.Rater;
+import org.dkpro.statistics.agreement.aligning.dissimilarity.IDissimilarity;
+
+/**
+ * Statistical continuum sampler for the gamma chance model, a port of pygamma-agreement's
+ * {@code StatisticalContinuumSampler} fused with the compute-sample-disorder job of
+ * {@code Continuum.compute_gamma}. Each call to {@link #sampleDisorder()} draws a fresh random
+ * continuum from the statistical characteristics of a reference continuum and returns its
+ * best-alignment disorder.
+ * <p>
+ * The reference statistics (all derived from the {@link GammaAgreement}'s continuum, using
+ * <b>population</b> mean/standard deviation to match numpy's {@code np.mean}/{@code np.std} with
+ * {@code ddof=0}) are:
+ * <ul>
+ * <li><b>gap</b> - the list is seeded with a single {@code 0} entry (a pygamma quirk that always
+ * lives in the list); for each rater the gap {@code start - previous_end} between consecutive units
+ * (may be negative, reproducing overlaps) is added; additionally each rater whose first unit starts
+ * beyond {@code 0} contributes that first start. Mirrors {@code _set_gap_information} exactly.</li>
+ * <li><b>duration</b> - over all units ({@code end - begin}).</li>
+ * <li><b>units per rater</b> - over the per-rater unit counts.</li>
+ * <li><b>category weights</b> - the relative frequency of each category value over all units, with
+ * categories enumerated in sorted order.</li>
+ * </ul>
+ * <p>
+ * <b>Category handling (Java adaptation of pygamma's single-annotation model).</b> pygamma stores a
+ * single scalar "annotation" (category) per unit. Units in this project instead carry a feature map,
+ * so the "category" of a unit is taken to be the value of exactly one feature. If the reference units
+ * collectively carry exactly one distinct feature name it is detected automatically; otherwise the
+ * explicit feature-name constructor must be used (an {@link IllegalArgumentException} is thrown). Every
+ * sampled unit carries exactly that one feature.
+ * <p>
+ * <b>Sampling one continuum (long adaptation, per PLAN &sect;3.6).</b> For each rater of the reference
+ * (the same {@link Rater} objects, in sorted order):
+ * <ol>
+ * <li>{@code nbUnits = abs((int) normal(avgUnits, stdUnits))} - the {@code (int)} cast truncates toward
+ * zero exactly like Python's {@code int()}. It is forced to {@code max(1, nbUnits)} only while the
+ * sampled continuum is still empty (pygamma's {@code if not new_continnum}: the first rater is always
+ * forced, later raters only if everything drawn so far was empty).</li>
+ * <li>Per unit: {@code gap = normal(avgGap, stdGap)}; {@code startD = lastPointD + gap};
+ * {@code durD = abs(normal(avgDur, stdDur))} redrawn while {@code round(startD + durD) - round(startD)
+ * < 1} (the integer analogue of pyannote's {@code SEGMENT_PRECISION} redraw); the unit gets
+ * {@code begin = round(startD)}, {@code end = round(startD + durD)}; the category is drawn by weighted
+ * choice; {@code lastPointD = startD + durD} accumulates in {@code double} so only per-unit rounding is
+ * applied and positions do not drift.</li>
+ * </ol>
+ * <p>
+ * All randomness is drawn from {@link GammaAgreement#getRandomGenerator()} so that a seed configured on
+ * the measure makes the sampling reproducible.
+ * <p>
+ * Deviations from the original:
+ * <ul>
+ * <li>Units carry {@code long} offsets; positions accumulate in {@code double} and are rounded per unit
+ * (pygamma keeps {@code float} coordinates). At character-offset scale this rounding perturbation is
+ * far below the 5%/1% sampling precision of the chance model.</li>
+ * <li>The duration redraw threshold is an integer {@code 1} instead of pyannote's
+ * {@code SEGMENT_PRECISION} (~{@code 1e-6}), because rounded units of zero length are the degenerate
+ * case here.</li>
+ * <li>Normal draws use {@code mean + sd * rng.nextGaussian()} rather than commons-math's
+ * {@code NormalDistribution}, which throws for {@code sd == 0}; numpy returns the mean in that case
+ * (and {@code sd == 0} happens routinely, e.g. equal unit counts across raters).</li>
+ * <li>The category is a feature value rather than pygamma's single scalar annotation (see above).</li>
+ * </ul>
+ *
+ * @see <a href="https://github.com/bootphon/pygamma-agreement">pygamma-agreement</a>
+ * @see <a href="https://aclanthology.org/J15-3003.pdf">Mathet et al. 2015</a>
+ */
+public class StatisticalContinuumDisorderSampler
+    implements IDisorderSampler
+{
+    private final AnnotationSet referenceContinuum;
+    private final IDissimilarity dissimilarity;
+    private final double deltaEmpty;
+    private final RandomGenerator rng;
+    private final String featureName;
+
+    // Raters of the reference, in sorted (canonical) order. Sampled continua reuse these objects.
+    private final List<Rater> raters;
+
+    private final double avgNbUnitsPerRater;
+    private final double stdNbUnitsPerRater;
+    private final double avgGap;
+    private final double stdGap;
+    private final double avgUnitDuration;
+    private final double stdUnitDuration;
+
+    // Category values in sorted order, with a parallel array of relative frequencies (weights).
+    private final String[] categories;
+    private final double[] categoryWeights;
+
+    /**
+     * Creates a sampler for the given measure, auto-detecting the category feature name.
+     *
+     * @param aMeasure
+     *            the gamma measure whose reference continuum, dissimilarity, delta-empty and source of
+     *            randomness are used.
+     * @throws IllegalArgumentException
+     *             if the reference units do not collectively carry exactly one distinct feature name
+     *             (use {@link #StatisticalContinuumDisorderSampler(GammaAgreement, String)} instead).
+     */
+    public StatisticalContinuumDisorderSampler(GammaAgreement aMeasure)
+    {
+        this(aMeasure, detectFeatureName(aMeasure.getAnnotationSet()));
+    }
+
+    /**
+     * Creates a sampler for the given measure using the named feature as the category.
+     *
+     * @param aMeasure
+     *            the gamma measure whose reference continuum, dissimilarity, delta-empty and source of
+     *            randomness are used.
+     * @param aFeatureName
+     *            the feature whose value is treated as each unit's category.
+     */
+    public StatisticalContinuumDisorderSampler(GammaAgreement aMeasure, String aFeatureName)
+    {
+        if (aFeatureName == null) {
+            throw new IllegalArgumentException("The category feature name must not be null.");
+        }
+
+        referenceContinuum = aMeasure.getAnnotationSet();
+        dissimilarity = aMeasure.getDissimilarity();
+        deltaEmpty = aMeasure.getDeltaEmpty();
+        rng = aMeasure.getRandomGenerator();
+        featureName = aFeatureName;
+
+        raters = new ArrayList<>(referenceContinuum.getRaters());
+
+        // --- number of units per rater ---
+        var nbUnits = new ArrayList<Double>();
+        for (var rater : raters) {
+            nbUnits.add((double) referenceContinuum.getUnitsWithRater(rater).size());
+        }
+        avgNbUnitsPerRater = populationMean(nbUnits);
+        stdNbUnitsPerRater = populationStd(nbUnits, avgNbUnitsPerRater);
+
+        // --- gaps (mirrors _set_gap_information exactly, including the always-present 0 seed) ---
+        var gaps = new ArrayList<Double>();
+        gaps.add(0.0);
+        for (var rater : raters) {
+            var units = referenceContinuum.getUnitsWithRater(rater);
+            for (int i = 1; i < units.size(); i++) {
+                gaps.add((double) (units.get(i).getBegin() - units.get(i - 1).getEnd()));
+            }
+        }
+        for (var rater : raters) {
+            var units = referenceContinuum.getUnitsWithRater(rater);
+            if (!units.isEmpty() && units.get(0).getBegin() > 0) {
+                gaps.add((double) units.get(0).getBegin());
+            }
+        }
+        avgGap = populationMean(gaps);
+        stdGap = populationStd(gaps, avgGap);
+
+        // --- durations (over all units) ---
+        var durations = new ArrayList<Double>();
+        for (var unit : referenceContinuum.getUnits()) {
+            durations.add((double) (unit.getEnd() - unit.getBegin()));
+        }
+        avgUnitDuration = populationMean(durations);
+        stdUnitDuration = populationStd(durations, avgUnitDuration);
+
+        // --- category weights (sorted order) ---
+        var counts = new TreeMap<String, Integer>();
+        int total = 0;
+        for (var unit : referenceContinuum.getUnits()) {
+            String category = unit.getFeatureValue(featureName);
+            counts.merge(category, 1, Integer::sum);
+            total++;
+        }
+        categories = counts.keySet().toArray(new String[0]);
+        categoryWeights = new double[categories.length];
+        for (int i = 0; i < categories.length; i++) {
+            categoryWeights[i] = counts.get(categories[i]) / (double) total;
+        }
+    }
+
+    private static String detectFeatureName(AnnotationSet aContinuum)
+    {
+        var names = aContinuum.getFeatureNames();
+        if (names.length != 1) {
+            throw new IllegalArgumentException(
+                    "Could not auto-detect the category feature: the reference units carry "
+                            + names.length + " distinct feature names " + List.of(names)
+                            + ", expected exactly one. Use the constructor that takes an explicit "
+                            + "feature name.");
+        }
+        return names[0];
+    }
+
+    @Override
+    public Double sampleDisorder()
+    {
+        // A rater whose unit count is drawn as zero vanishes from the sampled AnnotationSet (raters
+        // exist only through their units), and BestAlignmentSolver cannot align fewer than two
+        // raters. pygamma does not hit this because its Continuum retains annotators without
+        // segments. Deviation: we redraw instead. With small reference continua this skews the
+        // sample distribution towards continua where every rater has units, but such references
+        // are far below the sample sizes the chance model needs to be meaningful anyway.
+        var sample = sampleContinuum();
+        while (sample.getRaterCount() < 2) {
+            sample = sampleContinuum();
+        }
+
+        return BestAlignmentSolver.solve(sample, dissimilarity, deltaEmpty).disorder();
+    }
+
+    /**
+     * Draws one random continuum from the reference statistics. Package-private test seam.
+     */
+    AnnotationSet sampleContinuum()
+    {
+        var sampled = new ArrayList<AlignableAnnotationUnit>();
+        for (var rater : raters) {
+            double lastPointD = 0.0;
+
+            int nbUnits = Math.abs((int) normal(avgNbUnitsPerRater, stdNbUnitsPerRater));
+            // pygamma's "if not new_continnum": force at least one unit only while nothing has been
+            // sampled yet (the first rater is always forced; later raters only if all prior raters
+            // produced zero units).
+            if (sampled.isEmpty()) {
+                nbUnits = Math.max(1, nbUnits);
+            }
+
+            for (int k = 0; k < nbUnits; k++) {
+                double gap = normal(avgGap, stdGap);
+                double startD = lastPointD + gap;
+
+                double durD = Math.abs(normal(avgUnitDuration, stdUnitDuration));
+                // Redraw until the rounded segment spans at least one integer unit (integer analogue
+                // of pyannote's SEGMENT_PRECISION check). Guarantees begin < end.
+                while (Math.round(startD + durD) - Math.round(startD) < 1) {
+                    durD = Math.abs(normal(avgUnitDuration, stdUnitDuration));
+                }
+
+                long begin = Math.round(startD);
+                long end = Math.round(startD + durD);
+                String category = weightedCategory();
+
+                // 5-arg constructor with a null type: the 4-arg (Rater, long, long, Map) overload
+                // silently drops the features map, so it must not be used here.
+                sampled.add(new AlignableAnnotationUnit(rater, (String) null, begin, end,
+                        Map.of(featureName, category)));
+
+                lastPointD = startD + durD;
+            }
+        }
+
+        return new AnnotationSet(sampled);
+    }
+
+    /**
+     * Draws a normal value as {@code mean + sd * gaussian()}. Unlike commons-math's
+     * {@code NormalDistribution} this returns the mean for {@code sd == 0} rather than throwing.
+     */
+    private double normal(double aMean, double aStd)
+    {
+        return aMean + aStd * rng.nextGaussian();
+    }
+
+    private String weightedCategory()
+    {
+        double r = rng.nextDouble();
+        double cumulative = 0.0;
+        for (int i = 0; i < categories.length; i++) {
+            cumulative += categoryWeights[i];
+            if (r < cumulative) {
+                return categories[i];
+            }
+        }
+        return categories[categories.length - 1];
+    }
+
+    private static double populationMean(List<Double> aValues)
+    {
+        double sum = 0.0;
+        for (var v : aValues) {
+            sum += v;
+        }
+        return sum / aValues.size();
+    }
+
+    private static double populationStd(List<Double> aValues, double aMean)
+    {
+        double sum = 0.0;
+        for (var v : aValues) {
+            double d = v - aMean;
+            sum += d * d;
+        }
+        return Math.sqrt(sum / aValues.size());
+    }
+
+    // --- accessors (mainly for testing) ---
+
+    public String getFeatureName()
+    {
+        return featureName;
+    }
+
+    public double getAverageNumberOfUnitsPerRater()
+    {
+        return avgNbUnitsPerRater;
+    }
+
+    public double getStandardDeviationOfUnitsPerRater()
+    {
+        return stdNbUnitsPerRater;
+    }
+
+    public double getAverageGap()
+    {
+        return avgGap;
+    }
+
+    public double getStandardDeviationOfGap()
+    {
+        return stdGap;
+    }
+
+    public double getAverageUnitDuration()
+    {
+        return avgUnitDuration;
+    }
+
+    public double getStandardDeviationOfUnitDuration()
+    {
+        return stdUnitDuration;
+    }
+
+    public String[] getCategories()
+    {
+        return categories.clone();
+    }
+
+    public double[] getCategoryWeights()
+    {
+        return categoryWeights.clone();
+    }
+}

--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/aligning/dissimilarity/AbsoluteCategoricalDissimilarity.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/aligning/dissimilarity/AbsoluteCategoricalDissimilarity.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Ported from the pygamma-agreement project:
+ * https://github.com/bootphon/pygamma-agreement - version 0.5.9, commit 44587ef.
+ * Original file: pygamma_agreement/dissimilarity.py (AbsoluteCategoricalDissimilarity).
+ * Original authors: Rachid Riad, Hadrien Titeux, Léopold Favre.
+ *
+ * The original code is distributed under the MIT license, reproduced verbatim below:
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020-2021 CoML
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Paper: Mathet, Widlöcher, and Métivier (2015), "The Unified and Holistic Method
+ * Gamma for Inter-Annotator Agreement Measure and Alignment"
+ * (https://aclanthology.org/J15-3003.pdf).
+ */
+package org.dkpro.statistics.agreement.aligning.dissimilarity;
+
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import org.dkpro.statistics.agreement.aligning.AlignableAnnotationUnit;
+
+/**
+ * Basic categorical dissimilarity. It is {@code 0.0} when the two units carry identical feature sets
+ * (same names and same values) and {@code deltaEmpty} otherwise. The feature comparison follows the
+ * same semantics as {@link NominalFeatureDissimilarity}. Corresponds to the Python class
+ * {@code AbsoluteCategoricalDissimilarity} in pygamma-agreement.
+ * <p>
+ * Deviation from the original: pygamma compares a single scalar category index per unit, whereas
+ * the units in this project carry a feature map, so this implementation compares the full feature
+ * sets (name/value pairs) of the two units, matching {@link NominalFeatureDissimilarity}.
+ *
+ * @see <a href="https://github.com/bootphon/pygamma-agreement">pygamma-agreement</a>
+ * @see <a href="https://aclanthology.org/J15-3003.pdf">Mathet et al. 2015</a>
+ */
+public class AbsoluteCategoricalDissimilarity
+    extends AbstractDissimilarity
+{
+    public AbsoluteCategoricalDissimilarity()
+    {
+        this(1.0);
+    }
+
+    public AbsoluteCategoricalDissimilarity(double aDeltaEmpty)
+    {
+        super(aDeltaEmpty);
+    }
+
+    @Override
+    protected double dissimilarityInternal(AlignableAnnotationUnit aUnit1,
+            AlignableAnnotationUnit aUnit2)
+    {
+        Set<String> featureNames = new HashSet<String>();
+        featureNames.addAll(aUnit1.getFeatureNames());
+        featureNames.addAll(aUnit2.getFeatureNames());
+
+        for (String feature : featureNames) {
+            if (!Objects.equals(aUnit1.getFeatureValue(feature), aUnit2.getFeatureValue(feature))) {
+                return deltaEmpty;
+            }
+        }
+
+        return 0.0;
+    }
+}

--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/aligning/dissimilarity/AbstractDissimilarity.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/aligning/dissimilarity/AbstractDissimilarity.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Ported from the pygamma-agreement project:
+ * https://github.com/bootphon/pygamma-agreement - version 0.5.9, commit 44587ef.
+ * Original file: pygamma_agreement/dissimilarity.py (AbstractDissimilarity).
+ * Original authors: Rachid Riad, Hadrien Titeux, Léopold Favre.
+ *
+ * The original code is distributed under the MIT license, reproduced verbatim below:
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020-2021 CoML
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Paper: Mathet, Widlöcher, and Métivier (2015), "The Unified and Holistic Method
+ * Gamma for Inter-Annotator Agreement Measure and Alignment"
+ * (https://aclanthology.org/J15-3003.pdf).
+ */
+package org.dkpro.statistics.agreement.aligning.dissimilarity;
+
+import org.dkpro.statistics.agreement.aligning.AlignableAnnotationUnit;
+
+/**
+ * Base class for the pygamma-style dissimilarities. It centralizes the handling of "empty units":
+ * in the gamma measure any pair of units in which at least one unit is empty (i.e. {@code null})
+ * costs {@code deltaEmpty}. This mirrors {@code dissimilarity.py:_compute_alignment_disorders} in
+ * pygamma-agreement (https://github.com/bootphon/pygamma-agreement, MIT license), where a pair
+ * involving an empty unit always contributes {@code delta_empty}.
+ * <p>
+ * Corresponds to the Python class {@code AbstractDissimilarity}. Deviation from the original: in
+ * pygamma the empty-unit cost is applied by the alignment-disorder loop (which never calls the
+ * dissimilarity for an empty unit), whereas here the guard is centralized in this base class so
+ * that {@link #dissimilarity} itself is well-defined for {@code null} arguments.
+ *
+ * @see <a href="https://github.com/bootphon/pygamma-agreement">pygamma-agreement</a>
+ * @see <a href="https://aclanthology.org/J15-3003.pdf">Mathet et al. 2015</a>
+ */
+public abstract class AbstractDissimilarity
+    implements IDissimilarity
+{
+    /** Distance between a unit and a "null"/empty unit. Defaults to 1.0 in pygamma. */
+    protected final double deltaEmpty;
+
+    protected AbstractDissimilarity(double aDeltaEmpty)
+    {
+        deltaEmpty = aDeltaEmpty;
+    }
+
+    public double getDeltaEmpty()
+    {
+        return deltaEmpty;
+    }
+
+    @Override
+    public final double dissimilarity(AlignableAnnotationUnit aUnit1, AlignableAnnotationUnit aUnit2)
+    {
+        // Any pair involving an empty (null) unit - including a pair of two empty units - costs
+        // deltaEmpty. See pygamma dissimilarity.py:_compute_alignment_disorders.
+        if (aUnit1 == null || aUnit2 == null) {
+            return deltaEmpty;
+        }
+
+        return dissimilarityInternal(aUnit1, aUnit2);
+    }
+
+    /**
+     * Computes the dissimilarity for two guaranteed non-{@code null} units.
+     */
+    protected abstract double dissimilarityInternal(AlignableAnnotationUnit aUnit1,
+            AlignableAnnotationUnit aUnit2);
+}

--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/aligning/dissimilarity/CombinedCategoricalDissimilarity.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/aligning/dissimilarity/CombinedCategoricalDissimilarity.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Ported from the pygamma-agreement project:
+ * https://github.com/bootphon/pygamma-agreement - version 0.5.9, commit 44587ef.
+ * Original file: pygamma_agreement/dissimilarity.py (CombinedCategoricalDissimilarity).
+ * Original authors: Rachid Riad, Hadrien Titeux, Léopold Favre.
+ *
+ * The original code is distributed under the MIT license, reproduced verbatim below:
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020-2021 CoML
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Paper: Mathet, Widlöcher, and Métivier (2015), "The Unified and Holistic Method
+ * Gamma for Inter-Annotator Agreement Measure and Alignment"
+ * (https://aclanthology.org/J15-3003.pdf).
+ */
+package org.dkpro.statistics.agreement.aligning.dissimilarity;
+
+import org.dkpro.statistics.agreement.aligning.AlignableAnnotationUnit;
+
+/**
+ * Combined categorical dissimilarity taking both positioning and categorization of annotations into
+ * account:
+ *
+ * <pre>
+ * d(u, v) = alpha * positional.d(u, v) + beta * categorical.d(u, v)
+ * </pre>
+ *
+ * Defaults follow pygamma-agreement (https://github.com/bootphon/pygamma-agreement, MIT license):
+ * {@code alpha = 1}, {@code beta = 1}, {@code deltaEmpty = 1}, the positional part is a
+ * {@link PositionalSporadicDissimilarity} and the categorical part is an
+ * {@link AbsoluteCategoricalDissimilarity}, each constructed with {@code deltaEmpty}. Consistent with
+ * the other dissimilarities, any pair involving an empty ({@code null}) unit costs {@code deltaEmpty}.
+ * Corresponds to the Python class {@code CombinedCategoricalDissimilarity} in pygamma-agreement.
+ * <p>
+ * Deviation from the original: pygamma mutates the categorical sub-dissimilarity's {@code delta_empty}
+ * to match the combined value; here the sub-dissimilarities are immutable, so the default sub-parts
+ * are simply constructed with the combined {@code deltaEmpty} (custom sub-parts are used as given).
+ * The empty-unit guard (inherited from {@link AbstractDissimilarity}) returns the combined
+ * {@code deltaEmpty} directly rather than {@code alpha}/{@code beta}-weighting the sub-parts.
+ *
+ * @see <a href="https://github.com/bootphon/pygamma-agreement">pygamma-agreement</a>
+ * @see <a href="https://aclanthology.org/J15-3003.pdf">Mathet et al. 2015</a>
+ */
+public class CombinedCategoricalDissimilarity
+    extends AbstractDissimilarity
+{
+    private final double alpha;
+    private final double beta;
+    private final IDissimilarity positionalDissimilarity;
+    private final IDissimilarity categoricalDissimilarity;
+
+    public CombinedCategoricalDissimilarity()
+    {
+        this(builder());
+    }
+
+    public CombinedCategoricalDissimilarity(double aAlpha, double aBeta, double aDeltaEmpty,
+            IDissimilarity aPositionalDissimilarity, IDissimilarity aCategoricalDissimilarity)
+    {
+        super(aDeltaEmpty);
+        alpha = aAlpha;
+        beta = aBeta;
+        positionalDissimilarity = aPositionalDissimilarity != null ? aPositionalDissimilarity
+                : new PositionalSporadicDissimilarity(aDeltaEmpty);
+        categoricalDissimilarity = aCategoricalDissimilarity != null ? aCategoricalDissimilarity
+                : new AbsoluteCategoricalDissimilarity(aDeltaEmpty);
+    }
+
+    private CombinedCategoricalDissimilarity(Builder aBuilder)
+    {
+        this(aBuilder.alpha, aBuilder.beta, aBuilder.deltaEmpty, aBuilder.positionalDissimilarity,
+                aBuilder.categoricalDissimilarity);
+    }
+
+    public double getAlpha()
+    {
+        return alpha;
+    }
+
+    public double getBeta()
+    {
+        return beta;
+    }
+
+    @Override
+    protected double dissimilarityInternal(AlignableAnnotationUnit aUnit1,
+            AlignableAnnotationUnit aUnit2)
+    {
+        return alpha * positionalDissimilarity.dissimilarity(aUnit1, aUnit2)
+                + beta * categoricalDissimilarity.dissimilarity(aUnit1, aUnit2);
+    }
+
+    public static Builder builder()
+    {
+        return new Builder();
+    }
+
+    public static final class Builder
+    {
+        private double alpha = 1.0;
+        private double beta = 1.0;
+        private double deltaEmpty = 1.0;
+        private IDissimilarity positionalDissimilarity;
+        private IDissimilarity categoricalDissimilarity;
+
+        private Builder()
+        {
+        }
+
+        public Builder withAlpha(double aAlpha)
+        {
+            alpha = aAlpha;
+            return this;
+        }
+
+        public Builder withBeta(double aBeta)
+        {
+            beta = aBeta;
+            return this;
+        }
+
+        public Builder withDeltaEmpty(double aDeltaEmpty)
+        {
+            deltaEmpty = aDeltaEmpty;
+            return this;
+        }
+
+        public Builder withPositionalDissimilarity(IDissimilarity aPositionalDissimilarity)
+        {
+            positionalDissimilarity = aPositionalDissimilarity;
+            return this;
+        }
+
+        public Builder withCategoricalDissimilarity(IDissimilarity aCategoricalDissimilarity)
+        {
+            categoricalDissimilarity = aCategoricalDissimilarity;
+            return this;
+        }
+
+        public CombinedCategoricalDissimilarity build()
+        {
+            return new CombinedCategoricalDissimilarity(this);
+        }
+    }
+}

--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/aligning/dissimilarity/PositionalSporadicDissimilarity.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/aligning/dissimilarity/PositionalSporadicDissimilarity.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Ported from the pygamma-agreement project:
+ * https://github.com/bootphon/pygamma-agreement - version 0.5.9, commit 44587ef.
+ * Original file: pygamma_agreement/dissimilarity.py (PositionalSporadicDissimilarity).
+ * Original authors: Rachid Riad, Hadrien Titeux, Léopold Favre.
+ *
+ * The original code is distributed under the MIT license, reproduced verbatim below:
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020-2021 CoML
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Paper: Mathet, Widlöcher, and Métivier (2015), "The Unified and Holistic Method
+ * Gamma for Inter-Annotator Agreement Measure and Alignment"
+ * (https://aclanthology.org/J15-3003.pdf).
+ */
+package org.dkpro.statistics.agreement.aligning.dissimilarity;
+
+import org.dkpro.statistics.agreement.aligning.AlignableAnnotationUnit;
+
+/**
+ * Positional-sporadic dissimilarity. Takes only the position (begin/end offsets) of the annotations
+ * into account:
+ *
+ * <pre>
+ * d(u, v) = ((|begin_u - begin_v| + |end_u - end_v|) / ((end_u - begin_u) + (end_v - begin_v)))^2 * deltaEmpty
+ * </pre>
+ *
+ * It is {@code 0} for identical spans, {@code < deltaEmpty} when the spans fully overlap and
+ * {@code > deltaEmpty} when the spans are disjoint. Corresponds to the Python class
+ * {@code PositionalSporadicDissimilarity} in pygamma-agreement.
+ * <p>
+ * Deviation from the original: the units here expose {@code long} begin/end offsets (rather than
+ * pygamma's {@code float32} start/end/duration), so the arithmetic is performed in {@code double};
+ * the segment durations are derived as {@code end - begin} instead of being carried separately.
+ *
+ * @see <a href="https://github.com/bootphon/pygamma-agreement">pygamma-agreement</a>
+ * @see <a href="https://aclanthology.org/J15-3003.pdf">Mathet et al. 2015</a>
+ */
+public class PositionalSporadicDissimilarity
+    extends AbstractDissimilarity
+{
+    public PositionalSporadicDissimilarity()
+    {
+        this(1.0);
+    }
+
+    public PositionalSporadicDissimilarity(double aDeltaEmpty)
+    {
+        super(aDeltaEmpty);
+    }
+
+    @Override
+    protected double dissimilarityInternal(AlignableAnnotationUnit aUnit1,
+            AlignableAnnotationUnit aUnit2)
+    {
+        double distance = Math.abs((double) aUnit1.getBegin() - aUnit2.getBegin())
+                + Math.abs((double) aUnit1.getEnd() - aUnit2.getEnd());
+        double durations = (double) (aUnit1.getEnd() - aUnit1.getBegin())
+                + (double) (aUnit2.getEnd() - aUnit2.getBegin());
+
+        double ratio = distance / durations;
+
+        return ratio * ratio * deltaEmpty;
+    }
+}

--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/aligning/dissimilarity/PrecomputedCategoricalDissimilarity.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/aligning/dissimilarity/PrecomputedCategoricalDissimilarity.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Ported from the pygamma-agreement project:
+ * https://github.com/bootphon/pygamma-agreement - version 0.5.9, commit 44587ef.
+ * Original file: pygamma_agreement/dissimilarity.py (PrecomputedCategoricalDissimilarity).
+ * Original authors: Rachid Riad, Hadrien Titeux, Léopold Favre.
+ *
+ * The original code is distributed under the MIT license, reproduced verbatim below:
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020-2021 CoML
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ *
+ * Paper: Mathet, Widlöcher, and Métivier (2015), "The Unified and Holistic Method
+ * Gamma for Inter-Annotator Agreement Measure and Alignment"
+ * (https://aclanthology.org/J15-3003.pdf).
+ */
+package org.dkpro.statistics.agreement.aligning.dissimilarity;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+
+import org.dkpro.statistics.agreement.aligning.AlignableAnnotationUnit;
+
+/**
+ * Categorical dissimilarity backed by a precomputed category-to-category dissimilarity matrix:
+ *
+ * <pre>
+ * d(u, v) = matrix[index(cat_u)][index(cat_v)] * deltaEmpty
+ * </pre>
+ *
+ * where the category of a unit is the value of a configured feature. The rows and columns of the
+ * matrix follow the categories in <b>alphabetical order</b>: the categories passed to the
+ * constructor are sorted internally and each category is indexed by its position in that sorted
+ * order, exactly like the Python class {@code PrecomputedCategoricalDissimilarity} in
+ * pygamma-agreement. Callers must therefore lay out the matrix in alphabetical category order
+ * regardless of the order in which they pass the categories.
+ * <p>
+ * Deviation from the original: pygamma resolves the category via a scalar annotation index, whereas
+ * here the category is the value of a configurable unit feature; an unknown category value raises an
+ * {@link IllegalArgumentException}. The matrix is validated (square, matching dimensions, symmetric,
+ * zero diagonal) and defensively copied at construction time.
+ *
+ * @see <a href="https://github.com/bootphon/pygamma-agreement">pygamma-agreement</a>
+ * @see <a href="https://aclanthology.org/J15-3003.pdf">Mathet et al. 2015</a>
+ */
+public class PrecomputedCategoricalDissimilarity
+    extends AbstractDissimilarity
+{
+    private final String featureName;
+    private final double[][] matrix;
+    // Maps a category value to its row/column index in the (alphabetically sorted) matrix.
+    private final Map<String, Integer> categoryIndex;
+
+    public PrecomputedCategoricalDissimilarity(String aFeatureName, List<String> aCategories,
+            double[][] aMatrix, double aDeltaEmpty)
+    {
+        super(aDeltaEmpty);
+
+        if (aFeatureName == null) {
+            throw new IllegalArgumentException("Feature name must not be null.");
+        }
+        if (aCategories == null || aCategories.isEmpty()) {
+            throw new IllegalArgumentException("At least one category must be provided.");
+        }
+        if (aMatrix == null) {
+            throw new IllegalArgumentException("Dissimilarity matrix must not be null.");
+        }
+
+        featureName = aFeatureName;
+
+        // Sort categories alphabetically (defensively, de-duplicating) and index into the matrix by
+        // position in the sorted order. The matrix rows/columns are interpreted in this order.
+        List<String> sortedCategories = new ArrayList<String>(
+                new LinkedHashSet<String>(aCategories));
+        sortedCategories.sort(null);
+
+        categoryIndex = new TreeMap<String, Integer>();
+        for (int i = 0; i < sortedCategories.size(); i++) {
+            categoryIndex.put(sortedCategories.get(i), i);
+        }
+
+        int n = sortedCategories.size();
+
+        // Validate: square matrix with dimensions matching the number of (distinct) categories.
+        if (aMatrix.length != n) {
+            throw new IllegalArgumentException("Matrix has " + aMatrix.length + " rows but there are "
+                    + n + " categories.");
+        }
+        for (int i = 0; i < n; i++) {
+            if (aMatrix[i] == null || aMatrix[i].length != n) {
+                throw new IllegalArgumentException(
+                        "Matrix must be square (" + n + "x" + n + "). Offending row: " + i);
+            }
+        }
+
+        // Validate: zero diagonal and symmetry.
+        for (int i = 0; i < n; i++) {
+            if (aMatrix[i][i] != 0.0) {
+                throw new IllegalArgumentException(
+                        "Matrix diagonal must be zero. Offending entry: [" + i + "][" + i + "] = "
+                                + aMatrix[i][i]);
+            }
+            for (int j = i + 1; j < n; j++) {
+                if (aMatrix[i][j] != aMatrix[j][i]) {
+                    throw new IllegalArgumentException(
+                            "Matrix must be symmetric. Offending entries: [" + i + "][" + j + "] = "
+                                    + aMatrix[i][j] + " vs [" + j + "][" + i + "] = " + aMatrix[j][i]);
+                }
+            }
+        }
+
+        // Defensive copy.
+        matrix = new double[n][n];
+        for (int i = 0; i < n; i++) {
+            System.arraycopy(aMatrix[i], 0, matrix[i], 0, n);
+        }
+    }
+
+    private int indexOf(AlignableAnnotationUnit aUnit)
+    {
+        String category = aUnit.getFeatureValue(featureName);
+        Integer idx = categoryIndex.get(category);
+        if (idx == null) {
+            throw new IllegalArgumentException("Unknown category [" + category + "] for feature ["
+                    + featureName + "]. Known categories: " + categoryIndex.keySet());
+        }
+        return idx;
+    }
+
+    @Override
+    protected double dissimilarityInternal(AlignableAnnotationUnit aUnit1,
+            AlignableAnnotationUnit aUnit2)
+    {
+        return matrix[indexOf(aUnit1)][indexOf(aUnit2)] * deltaEmpty;
+    }
+}

--- a/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/aligning/GammaAgreementEndToEndTest.java
+++ b/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/aligning/GammaAgreementEndToEndTest.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.statistics.agreement.aligning;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+
+import org.dkpro.statistics.agreement.aligning.disorder.StatisticalContinuumDisorderSampler;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Tier-3 statistical validation of the full gamma pipeline (observed disorder + statistical continuum
+ * sampler + expected disorder). Both the Java side and the pygamma reference are 30-sample Monte-Carlo
+ * estimates over independent PRNG streams, so gamma values are only <em>statistically</em> comparable,
+ * not bit-identical.
+ */
+class GammaAgreementEndToEndTest
+{
+    private static final long SEED = 20240704L;
+
+    /** Loose Monte-Carlo band: both sides are independent 30-sample estimates. */
+    private static final double GAMMA_BAND = 0.2;
+
+    static Stream<String> fixtures() throws IOException
+    {
+        return PygammaFixtures.fixtures();
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("fixtures")
+    void gammaMatchesPygammaWithinMonteCarloBand(String aFixture)
+    {
+        var root = PygammaFixtures.load(aFixture);
+        var continuum = PygammaFixtures.buildContinuum(root);
+        var dissimilarity = PygammaFixtures.buildDissimilarity(root);
+
+        var gamma = GammaAgreement.builder() //
+                .withAnnotationSet(continuum) //
+                .withDissimilarity(dissimilarity) //
+                .withDisorderSampler(StatisticalContinuumDisorderSampler::new) //
+                .withSeed(SEED) //
+                .build();
+
+        double gammaJava = gamma.calculateAgreement();
+        double gammaPy = root.get("tier3").get("gamma").asDouble();
+
+        assertThat(Double.isFinite(gammaJava)).as("%s: gamma must be finite", aFixture).isTrue();
+        assertThat(gammaJava).as("%s: gamma <= 1", aFixture).isLessThanOrEqualTo(1.0);
+
+        if ("fixture_03_identical_perfect.json".equals(aFixture)) {
+            // Observed disorder is exactly 0 for a perfect continuum -> gamma == 1 without sampling.
+            assertThat(gammaJava).as("%s: perfect continuum gamma", aFixture).isEqualTo(1.0);
+        }
+        else {
+            assertThat(gammaJava).as("%s: gamma_java=%s vs tier3 gamma=%s", aFixture, gammaJava,
+                    gammaPy).isCloseTo(gammaPy, offset(GAMMA_BAND));
+        }
+    }
+
+    @Test
+    void expectedDisorderMatchesPygammaWithLargeSampleCount()
+    {
+        // A mid-size fixture (32 units, 2 raters, 3 categories) with a tighter statistical check:
+        // 300 samples on each side should agree on the expected disorder within 15% relative.
+        var root = PygammaFixtures.load("fixture_05_larger_two_annotators.json");
+        var continuum = PygammaFixtures.buildContinuum(root);
+        var dissimilarity = PygammaFixtures.buildDissimilarity(root);
+
+        var gamma = GammaAgreement.builder() //
+                .withAnnotationSet(continuum) //
+                .withDissimilarity(dissimilarity) //
+                .withDisorderSampler(StatisticalContinuumDisorderSampler::new) //
+                .withSeed(SEED) //
+                .withNumberOfSamples(300) //
+                .build();
+
+        double expectedJava = gamma.calculateExpectedDisagreement();
+        double expectedPy = root.get("tier3").get("expectedDisorder").asDouble();
+
+        double relative = Math.abs(expectedJava - expectedPy) / expectedPy;
+
+        // Do NOT widen this band: a failure indicates a sampler-distribution mismatch worth
+        // investigating, not a flaky test.
+        assertThat(relative)
+                .as("expected disorder java=%s vs pygamma=%s (relative diff %s)", expectedJava,
+                        expectedPy, relative)
+                .isLessThan(0.15);
+    }
+
+    @Test
+    void sameSeedProducesIdenticalGamma()
+    {
+        var root = PygammaFixtures.load("fixture_01_two_annotators_simple.json");
+        var continuum = PygammaFixtures.buildContinuum(root);
+        var dissimilarity = PygammaFixtures.buildDissimilarity(root);
+
+        double first = GammaAgreement.builder().withAnnotationSet(continuum)
+                .withDissimilarity(dissimilarity)
+                .withDisorderSampler(StatisticalContinuumDisorderSampler::new).withSeed(SEED).build()
+                .calculateAgreement();
+        double second = GammaAgreement.builder().withAnnotationSet(continuum)
+                .withDissimilarity(dissimilarity)
+                .withDisorderSampler(StatisticalContinuumDisorderSampler::new).withSeed(SEED).build()
+                .calculateAgreement();
+
+        assertThat(first).isEqualTo(second);
+    }
+}

--- a/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/aligning/GammaAgreementFixtureTest.java
+++ b/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/aligning/GammaAgreementFixtureTest.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.statistics.agreement.aligning;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+
+import java.io.IOException;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.stream.Stream;
+
+import org.dkpro.statistics.agreement.aligning.alignment.BestAlignmentSolver;
+import org.dkpro.statistics.agreement.aligning.data.AnnotationSet;
+import org.dkpro.statistics.agreement.aligning.disorder.IDisorderSampler;
+import org.dkpro.statistics.agreement.aligning.dissimilarity.CombinedCategoricalDissimilarity;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+/**
+ * Cross-validation of {@link GammaAgreement} against pygamma-agreement fixtures.
+ * <ul>
+ * <li><b>Tier 1</b>: observed disagreement equals the reference best-alignment disorder.</li>
+ * <li><b>Tier 2</b>: for every sampled continuum, the disorder computed on its scaled integer units
+ * equals the reference; feeding all sampled continua through a replay sampler reproduces the expected
+ * disorder (their mean) and the resulting gamma.</li>
+ * <li><b>Tier 3</b>: sanity - gamma is finite, and exactly 1.0 for the identical-annotator
+ * fixture.</li>
+ * </ul>
+ */
+public class GammaAgreementFixtureTest
+{
+    /** pygamma computes in float32 -> relative tolerance ~1e-5 on disorders. */
+    private static final double REL_TOL = 1e-5;
+
+    static Stream<String> fixtures() throws IOException
+    {
+        return PygammaFixtures.fixtures();
+    }
+
+    /**
+     * Replays the fixture's scaled sampled continua: each {@code sampleDisorder()} call pops the next
+     * continuum and computes its best-alignment disorder with the real solver. This exercises the
+     * full sampler -> solver -> mean pipeline.
+     */
+    private static final class ReplaySampler
+        implements IDisorderSampler
+    {
+        private final Deque<AnnotationSet> queue;
+        private final CombinedCategoricalDissimilarity dissimilarity;
+
+        ReplaySampler(Deque<AnnotationSet> aQueue, CombinedCategoricalDissimilarity aDissimilarity)
+        {
+            queue = aQueue;
+            dissimilarity = aDissimilarity;
+        }
+
+        @Override
+        public Double sampleDisorder()
+        {
+            return BestAlignmentSolver.solve(queue.removeFirst(), dissimilarity).disorder();
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("fixtures")
+    void tier1ObservedDisagreementMatches(String aFixture)
+    {
+        JsonNode root = PygammaFixtures.load(aFixture);
+        var gamma = GammaAgreement.builder() //
+                .withAnnotationSet(PygammaFixtures.buildContinuum(root)) //
+                .withDissimilarity(PygammaFixtures.buildDissimilarity(root)) //
+                .build();
+
+        double expected = root.get("tier1").get("bestAlignmentDisorder").asDouble();
+        double tolerance = Math.max(REL_TOL * Math.abs(expected), 1e-9);
+        assertThat(gamma.calculateObservedDisagreement()).isCloseTo(expected, offset(tolerance));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("fixtures")
+    void tier2ScaledSampleDisordersMatch(String aFixture)
+    {
+        JsonNode root = PygammaFixtures.load(aFixture);
+        var dissimilarity = PygammaFixtures.buildDissimilarity(root);
+
+        for (JsonNode sample : root.get("tier2").get("sampledContinua")) {
+            JsonNode scaled = sample.get("scaled");
+            var set = PygammaFixtures.buildAnnotationSet(scaled.get("units"));
+            double expected = scaled.get("bestAlignmentDisorder").asDouble();
+
+            double actual = BestAlignmentSolver.solve(set, dissimilarity).disorder();
+
+            double tolerance = Math.max(REL_TOL * Math.abs(expected), 1e-9);
+            assertThat(actual).isCloseTo(expected, offset(tolerance));
+        }
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("fixtures")
+    void tier2ReplayReproducesExpectedDisorderAndGamma(String aFixture)
+    {
+        JsonNode root = PygammaFixtures.load(aFixture);
+        var dissimilarity = PygammaFixtures.buildDissimilarity(root);
+
+        JsonNode samples = root.get("tier2").get("sampledContinua");
+        var queue = new ArrayDeque<AnnotationSet>();
+        double sumScaled = 0;
+        for (JsonNode sample : samples) {
+            JsonNode scaled = sample.get("scaled");
+            queue.add(PygammaFixtures.buildAnnotationSet(scaled.get("units")));
+            sumScaled += scaled.get("bestAlignmentDisorder").asDouble();
+        }
+        int nSamples = samples.size();
+        double meanScaled = sumScaled / nSamples;
+
+        var gamma = GammaAgreement.builder() //
+                .withAnnotationSet(PygammaFixtures.buildContinuum(root)) //
+                .withDissimilarity(dissimilarity) //
+                .withDisorderSampler(new ReplaySampler(queue, dissimilarity)) //
+                .withNumberOfSamples(nSamples) //
+                .withPrecisionLevel(null) //
+                .build();
+
+        double expectedDisorder = gamma.calculateExpectedDisagreement();
+        assertThat(expectedDisorder)
+                .isCloseTo(meanScaled, offset(Math.max(REL_TOL * Math.abs(meanScaled), 1e-9)));
+        assertThat(gamma.getExpectedDisagreementSampleCount()).isEqualTo(nSamples);
+
+        double tier1Obs = root.get("tier1").get("bestAlignmentDisorder").asDouble();
+        double expectedGamma = tier1Obs == 0.0 ? 1.0 : 1.0 - tier1Obs / meanScaled;
+
+        // Fresh instance so the observed disorder is recomputed from scratch alongside the replay.
+        var replayQueue = new ArrayDeque<AnnotationSet>();
+        for (JsonNode sample : samples) {
+            replayQueue.add(PygammaFixtures.buildAnnotationSet(sample.get("scaled").get("units")));
+        }
+        var gammaForAgreement = GammaAgreement.builder() //
+                .withAnnotationSet(PygammaFixtures.buildContinuum(root)) //
+                .withDissimilarity(dissimilarity) //
+                .withDisorderSampler(new ReplaySampler(replayQueue, dissimilarity)) //
+                .withNumberOfSamples(nSamples) //
+                .withPrecisionLevel(null) //
+                .build();
+
+        double actualGamma = gammaForAgreement.calculateAgreement();
+        assertThat(actualGamma)
+                .isCloseTo(expectedGamma, offset(Math.max(1e-4 * Math.abs(expectedGamma), 1e-9)));
+
+        // Tier 3 sanity: gamma is finite.
+        assertThat(Double.isFinite(actualGamma)).isTrue();
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("fixtures")
+    void tier3GammaIsFinite(String aFixture)
+    {
+        JsonNode root = PygammaFixtures.load(aFixture);
+        var dissimilarity = PygammaFixtures.buildDissimilarity(root);
+
+        JsonNode samples = root.get("tier2").get("sampledContinua");
+        var queue = new ArrayDeque<AnnotationSet>();
+        for (JsonNode sample : samples) {
+            queue.add(PygammaFixtures.buildAnnotationSet(sample.get("scaled").get("units")));
+        }
+
+        var gamma = GammaAgreement.builder() //
+                .withAnnotationSet(PygammaFixtures.buildContinuum(root)) //
+                .withDissimilarity(dissimilarity) //
+                .withDisorderSampler(new ReplaySampler(queue, dissimilarity)) //
+                .withNumberOfSamples(samples.size()) //
+                .build();
+
+        double value = gamma.calculateAgreement();
+        assertThat(Double.isFinite(value)).isTrue();
+
+        // fixture_03 has identical annotators -> observed disorder 0 -> gamma exactly 1.0.
+        if (aFixture.startsWith("fixture_03")) {
+            assertThat(value).isEqualTo(1.0);
+        }
+    }
+}

--- a/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/aligning/GammaAgreementTest.java
+++ b/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/aligning/GammaAgreementTest.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.statistics.agreement.aligning;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.offset;
+
+import java.util.List;
+import java.util.Map;
+
+import org.dkpro.statistics.agreement.InsufficientDataException;
+import org.dkpro.statistics.agreement.aligning.data.AnnotationSet;
+import org.dkpro.statistics.agreement.aligning.data.Rater;
+import org.dkpro.statistics.agreement.aligning.disorder.IDisorderSampler;
+import org.junit.jupiter.api.Test;
+
+class GammaAgreementTest
+{
+    private static final Rater ANNOTATOR_A = new Rater("A", 0);
+    private static final Rater ANNOTATOR_B = new Rater("B", 1);
+
+    /**
+     * Sampler that replays a scripted sequence of disorders and falls back to a fixed value once the
+     * sequence is exhausted, counting the total number of draws.
+     */
+    private static final class CountingSampler
+        implements IDisorderSampler
+    {
+        private final double[] scripted;
+        private final double fallback;
+        private int count = 0;
+
+        CountingSampler(double fallback, double... scripted)
+        {
+            this.scripted = scripted;
+            this.fallback = fallback;
+        }
+
+        @Override
+        public Double sampleDisorder()
+        {
+            double value = count < scripted.length ? scripted[count] : fallback;
+            count++;
+            return value;
+        }
+
+        int count()
+        {
+            return count;
+        }
+    }
+
+    private static AnnotationSet perfectContinuum()
+    {
+        // Two raters with identical units -> best-alignment disorder is exactly 0.
+        return new AnnotationSet(List.of( //
+                unit(ANNOTATOR_A, 0, 4, "a"), //
+                unit(ANNOTATOR_A, 5, 9, "b"), //
+                unit(ANNOTATOR_B, 0, 4, "a"), //
+                unit(ANNOTATOR_B, 5, 9, "b")));
+    }
+
+    private static AnnotationSet disagreeingContinuum()
+    {
+        // Two raters, one shifted unit each -> positive observed disorder.
+        return new AnnotationSet(List.of( //
+                unit(ANNOTATOR_A, 0, 4, "a"), //
+                unit(ANNOTATOR_B, 2, 6, "a")));
+    }
+
+    private static AlignableAnnotationUnit unit(Rater aRater, long aBegin, long aEnd, String aCat)
+    {
+        return new AlignableAnnotationUnit(aRater, null, aBegin, aEnd, Map.of("category", aCat));
+    }
+
+    @Test
+    void missingAnnotationSetIsRejected()
+    {
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> GammaAgreement.builder().build());
+    }
+
+    @Test
+    void singleRaterIsRejected()
+    {
+        var set = new AnnotationSet(List.of(unit(ANNOTATOR_A, 0, 4, "a")));
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> GammaAgreement.builder().withAnnotationSet(set).build());
+    }
+
+    @Test
+    void invalidPrecisionLevelIsRejected()
+    {
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> GammaAgreement
+                .builder().withAnnotationSet(perfectContinuum()).withPrecisionLevel(1.5).build());
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> GammaAgreement
+                .builder().withAnnotationSet(perfectContinuum()).withPrecisionLevel(0.0).build());
+    }
+
+    @Test
+    void invalidNumberOfSamplesIsRejected()
+    {
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> GammaAgreement
+                .builder().withAnnotationSet(perfectContinuum()).withNumberOfSamples(0).build());
+    }
+
+    @Test
+    void expectedDisagreementWithoutPrecisionIsMeanOfFirstN()
+    {
+        var sampler = new CountingSampler(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0);
+        var gamma = GammaAgreement.builder() //
+                .withAnnotationSet(disagreeingContinuum()) //
+                .withDisorderSampler(sampler) //
+                .withNumberOfSamples(5) //
+                .withPrecisionLevel(null) //
+                .build();
+
+        // Mean of the first 5 scripted values (1+2+3+4+5)/5 = 3.0, exactly 5 draws, no top-up.
+        assertThat(gamma.calculateExpectedDisagreement()).isCloseTo(3.0, offset(1e-12));
+        assertThat(sampler.count()).isEqualTo(5);
+        assertThat(gamma.getExpectedDisagreementSampleCount()).isEqualTo(5);
+    }
+
+    @Test
+    void expectedDisagreementWithZeroVarianceDoesNotTopUp()
+    {
+        var sampler = new CountingSampler(2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0);
+        var gamma = GammaAgreement.builder() //
+                .withAnnotationSet(disagreeingContinuum()) //
+                .withDisorderSampler(sampler) //
+                .withNumberOfSamples(10) //
+                .withPrecisionLevel(0.05) //
+                .build();
+
+        // cv == 0 -> required == 0 -> no top-up; exactly 10 draws, mean == 2.0.
+        assertThat(gamma.calculateExpectedDisagreement()).isCloseTo(2.0, offset(1e-12));
+        assertThat(sampler.count()).isEqualTo(10);
+        assertThat(gamma.getExpectedDisagreementSampleCount()).isEqualTo(10);
+    }
+
+    @Test
+    void expectedDisagreementWithHighVarianceTopsUpExactlyOnce()
+    {
+        // First batch [1,3,1,3]: mean 2.0, population std 1.0, cv 0.5.
+        // required = ceil((0.5 * 1.96 / 0.05)^2) = ceil(384.16) = 385.
+        // top-up = 385 - 4 = 381, all equal to the fallback 2.0 so the overall mean stays 2.0.
+        var sampler = new CountingSampler(2.0, 1.0, 3.0, 1.0, 3.0);
+        var gamma = GammaAgreement.builder() //
+                .withAnnotationSet(disagreeingContinuum()) //
+                .withDisorderSampler(sampler) //
+                .withNumberOfSamples(4) //
+                .withPrecisionLevel(0.05) //
+                .build();
+
+        assertThat(gamma.calculateExpectedDisagreement()).isCloseTo(2.0, offset(1e-12));
+        assertThat(sampler.count()).isEqualTo(385);
+        assertThat(gamma.getExpectedDisagreementSampleCount()).isEqualTo(385);
+    }
+
+    @Test
+    void observedZeroYieldsGammaOneWithoutSampling()
+    {
+        // Sampler that fails if invoked - proves the obs == 0 short-circuit never draws samples.
+        IDisorderSampler failing = () -> {
+            throw new AssertionError("sampler must not be called when observed disorder is zero");
+        };
+        var gamma = GammaAgreement.builder() //
+                .withAnnotationSet(perfectContinuum()) //
+                .withDisorderSampler(failing) //
+                .build();
+
+        assertThat(gamma.calculateObservedDisagreement()).isCloseTo(0.0, offset(1e-12));
+        assertThat(gamma.calculateAgreement()).isEqualTo(1.0);
+    }
+
+    @Test
+    void zeroExpectedWithPositiveObservedThrows()
+    {
+        var gamma = GammaAgreement.builder() //
+                .withAnnotationSet(disagreeingContinuum()) //
+                .withDisorderSampler(() -> 0.0) //
+                .withNumberOfSamples(5) //
+                .build();
+
+        assertThat(gamma.calculateObservedDisagreement()).isGreaterThan(0.0);
+        assertThatExceptionOfType(InsufficientDataException.class)
+                .isThrownBy(gamma::calculateAgreement);
+    }
+
+    @Test
+    void missingSamplerThrowsLazilyOnExpectedDisagreement()
+    {
+        var gamma = GammaAgreement.builder() //
+                .withAnnotationSet(disagreeingContinuum()) //
+                .build();
+
+        // Observed disorder works without a sampler ...
+        assertThat(gamma.calculateObservedDisagreement()).isGreaterThan(0.0);
+        // ... but the expected disorder requires one.
+        assertThatExceptionOfType(IllegalStateException.class)
+                .isThrownBy(gamma::calculateExpectedDisagreement);
+    }
+
+    @Test
+    void agreementIsOneMinusObservedOverExpected()
+    {
+        var set = disagreeingContinuum();
+        var observed = GammaAgreement.builder().withAnnotationSet(set).build()
+                .calculateObservedDisagreement();
+
+        var gamma = GammaAgreement.builder() //
+                .withAnnotationSet(set) //
+                .withDisorderSampler(() -> 1.0) //
+                .withNumberOfSamples(10) //
+                .build();
+
+        // expected == 1.0 -> gamma == 1 - observed / 1.0.
+        assertThat(gamma.calculateAgreement()).isCloseTo(1.0 - observed, offset(1e-9));
+    }
+}

--- a/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/aligning/PygammaFixtures.java
+++ b/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/aligning/PygammaFixtures.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.statistics.agreement.aligning;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.dkpro.statistics.agreement.aligning.data.AnnotationSet;
+import org.dkpro.statistics.agreement.aligning.data.Rater;
+import org.dkpro.statistics.agreement.aligning.dissimilarity.CombinedCategoricalDissimilarity;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Shared loader for the pygamma cross-validation fixtures under
+ * {@code src/test/resources/pygamma}. Reused by the tier-1/tier-2/tier-3 tests so the JSON schema is
+ * decoded in exactly one place.
+ */
+public final class PygammaFixtures
+{
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    public static final String FIXTURE_DIR = "src/test/resources/pygamma";
+
+    private PygammaFixtures()
+    {
+        // utility class
+    }
+
+    /**
+     * @return the sorted file names of all {@code fixture_*.json} files, for use as a JUnit
+     *         {@code @MethodSource}.
+     */
+    public static Stream<String> fixtures() throws IOException
+    {
+        var names = new ArrayList<String>();
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(Paths.get(FIXTURE_DIR),
+                "fixture_*.json")) {
+            for (Path p : stream) {
+                names.add(p.getFileName().toString());
+            }
+        }
+        names.sort(String::compareTo);
+        return names.stream();
+    }
+
+    public static JsonNode load(String aFixture)
+    {
+        try (InputStream is = Files.newInputStream(Paths.get(FIXTURE_DIR, aFixture))) {
+            return MAPPER.readTree(is);
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    /**
+     * Builds an {@link AnnotationSet} from the top-level {@code continuum} array of a fixture.
+     */
+    public static AnnotationSet buildContinuum(JsonNode aRoot)
+    {
+        return buildAnnotationSet(aRoot.get("continuum"));
+    }
+
+    /**
+     * Builds an {@link AnnotationSet} from an array of unit entries (each with
+     * {@code annotator}/{@code start}/{@code end}/{@code category} keys and integral offsets). Works
+     * both for the top-level {@code continuum} and for a sampled continuum's {@code scaled.units}.
+     */
+    public static AnnotationSet buildAnnotationSet(JsonNode aUnitsArray)
+    {
+        var raters = new HashMap<String, Rater>();
+        var units = new ArrayList<AlignableAnnotationUnit>();
+        for (JsonNode entry : aUnitsArray) {
+            String annotator = entry.get("annotator").asText();
+            var rater = raters.computeIfAbsent(annotator, name -> new Rater(name, raters.size()));
+            long start = entry.get("start").asLong();
+            long end = entry.get("end").asLong();
+            String category = entry.get("category").asText();
+            units.add(new AlignableAnnotationUnit(rater, null, start, end,
+                    Map.of("category", category)));
+        }
+        return new AnnotationSet(units);
+    }
+
+    /**
+     * Builds the combined categorical dissimilarity from a fixture's {@code params} block.
+     */
+    public static CombinedCategoricalDissimilarity buildDissimilarity(JsonNode aRoot)
+    {
+        JsonNode params = aRoot.get("params");
+        return CombinedCategoricalDissimilarity.builder() //
+                .withAlpha(params.get("alpha").asDouble()) //
+                .withBeta(params.get("beta").asDouble()) //
+                .withDeltaEmpty(params.get("deltaEmpty").asDouble()) //
+                .build();
+    }
+}

--- a/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/aligning/alignment/BestAlignmentFixtureTest.java
+++ b/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/aligning/alignment/BestAlignmentFixtureTest.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.statistics.agreement.aligning.alignment;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+
+import java.io.IOException;
+import java.util.stream.Stream;
+
+import org.dkpro.statistics.agreement.aligning.PygammaFixtures;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class BestAlignmentFixtureTest
+{
+    static Stream<String> fixtures() throws IOException
+    {
+        return PygammaFixtures.fixtures();
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("fixtures")
+    void tier1BestAlignmentDisorderMatches(String aFixture)
+    {
+        JsonNode root = PygammaFixtures.load(aFixture);
+        var set = PygammaFixtures.buildContinuum(root);
+        var d = PygammaFixtures.buildDissimilarity(root);
+
+        double expected = root.get("tier1").get("bestAlignmentDisorder").asDouble();
+
+        var result = BestAlignmentSolver.solve(set, d);
+
+        // pygamma computes in float32; use a relative tolerance of 1e-5 with a small absolute floor
+        // so the exact-zero fixture is handled gracefully.
+        double tolerance = Math.max(1e-5 * Math.abs(expected), 1e-9);
+        assertThat(result.disorder()).isCloseTo(expected, offset(tolerance));
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("fixtures")
+    void internalConsistencyAlignmentDisorderMatchesIlpSum(String aFixture)
+    {
+        JsonNode root = PygammaFixtures.load(aFixture);
+        var set = PygammaFixtures.buildContinuum(root);
+        var d = PygammaFixtures.buildDissimilarity(root);
+
+        var result = BestAlignmentSolver.solve(set, d);
+
+        assertThat(result.alignment().getDisorder(d)).isCloseTo(result.disorder(), offset(1e-9));
+    }
+}

--- a/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/aligning/alignment/BestAlignmentSolverTest.java
+++ b/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/aligning/alignment/BestAlignmentSolverTest.java
@@ -1,0 +1,232 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.statistics.agreement.aligning.alignment;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.offset;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.dkpro.statistics.agreement.aligning.AlignableAnnotationUnit;
+import org.dkpro.statistics.agreement.aligning.data.AnnotationSet;
+import org.dkpro.statistics.agreement.aligning.data.Rater;
+import org.dkpro.statistics.agreement.aligning.dissimilarity.CombinedCategoricalDissimilarity;
+import org.junit.jupiter.api.Test;
+
+public class BestAlignmentSolverTest
+{
+    private static final Rater ANN1 = new Rater("Ann1", 0);
+    private static final Rater ANN2 = new Rater("Ann2", 1);
+
+    private static AlignableAnnotationUnit unit(Rater aRater, long aBegin, long aEnd, String aCategory)
+    {
+        return new AlignableAnnotationUnit(aRater, null, aBegin, aEnd, Map.of("category", aCategory));
+    }
+
+    private static CombinedCategoricalDissimilarity dissimilarity()
+    {
+        return CombinedCategoricalDissimilarity.builder().build();
+    }
+
+    @Test
+    void testTwoIdenticalUnitsDisorderIsZero()
+    {
+        var units = asList( //
+                unit(ANN1, 0, 10, "a"), //
+                unit(ANN2, 0, 10, "a"));
+        var set = new AnnotationSet(units);
+
+        var result = BestAlignmentSolver.solve(set, dissimilarity());
+
+        // The two units are paired, no empty pairing -> disorder 0.
+        assertThat(result.disorder()).isCloseTo(0.0, offset(1e-12));
+    }
+
+    @Test
+    void testDisjointUnitsBestIsEmptyPairing()
+    {
+        // Far-apart units: pairing them is not even a valid candidate (positional dissim >> criterion),
+        // so the best alignment pairs each with the empty unit. Each singleton costs deltaEmpty = 1;
+        // sum = 2, divided by avg annotations (2/2 = 1) -> disorder 2.
+        var units = asList( //
+                unit(ANN1, 0, 10, "a"), //
+                unit(ANN2, 1000, 1010, "b"));
+        var set = new AnnotationSet(units);
+
+        var result = BestAlignmentSolver.solve(set, dissimilarity());
+
+        assertThat(result.disorder()).isCloseTo(2.0, offset(1e-12));
+    }
+
+    @Test
+    void testPairingBeatsEmptyPairing()
+    {
+        // Close units, same category: pairing disorder = ((1+1)/20)^2 = 0.01, far below the
+        // two-singletons cost of 2. Best disorder = 0.01.
+        var units = asList( //
+                unit(ANN1, 0, 10, "a"), //
+                unit(ANN2, 1, 11, "a"));
+        var set = new AnnotationSet(units);
+
+        var result = BestAlignmentSolver.solve(set, dissimilarity());
+
+        assertThat(result.disorder()).isCloseTo(0.01, offset(1e-9));
+    }
+
+    @Test
+    void testInternalConsistencyDisorderMatchesAlignment()
+    {
+        var units = asList( //
+                unit(ANN1, 0, 10, "a"), //
+                unit(ANN1, 20, 30, "b"), //
+                unit(ANN2, 1, 11, "a"), //
+                unit(ANN2, 100, 110, "b"));
+        var set = new AnnotationSet(units);
+        var d = dissimilarity();
+
+        var result = BestAlignmentSolver.solve(set, d);
+
+        assertThat(result.alignment().getDisorder(d)).isCloseTo(result.disorder(), offset(1e-9));
+    }
+
+    @Test
+    void testPrunedCandidatesRespectCriterion()
+    {
+        // A far pairing (Ann1[0,10] with Ann2[1000,1010]) must be pruned: its unitary-alignment
+        // disorder exceeds n * deltaEmpty = 2.
+        var far1 = unit(ANN1, 0, 10, "a");
+        var far2 = unit(ANN2, 1000, 1010, "b");
+        var near1 = unit(ANN1, 100, 110, "a");
+        var near2 = unit(ANN2, 101, 111, "a");
+        var set = new AnnotationSet(asList(far1, far2, near1, near2));
+        double deltaEmpty = 1.0;
+        int n = 2;
+
+        var candidates = BestAlignmentSolver.generateCandidates(set, dissimilarity(), deltaEmpty);
+
+        // Every kept candidate must satisfy the pruning criterion.
+        for (double disorder : candidates.disorders()) {
+            assertThat(disorder).isLessThanOrEqualTo(n * deltaEmpty + 1e-9);
+        }
+
+        // Specifically, no candidate must pair far1 with far2. far1 is Ann1's unit at index 0 (begin
+        // 0 < 100), far2 is Ann2's unit at index 1 (begin 1000 > 101). A candidate pairing them would
+        // have Ann1 index 0 and Ann2 index 1 both non-empty.
+        var raters = candidates.raters();
+        int ann1Idx = raters.indexOf(ANN1);
+        int ann2Idx = raters.indexOf(ANN2);
+        int far1Index = candidates.unitsPerRater().get(ann1Idx).indexOf(far1);
+        int far2Index = candidates.unitsPerRater().get(ann2Idx).indexOf(far2);
+        for (int[] tuple : candidates.tuples()) {
+            boolean pairsFarUnits = tuple[ann1Idx] == far1Index && tuple[ann2Idx] == far2Index;
+            assertThat(pairsFarUnits).isFalse();
+        }
+    }
+
+    @Test
+    void testTooLargeContinuumIsRejected()
+    {
+        // Build a continuum whose cartesian product Π(n_i + 1) exceeds MAX_PRODUCT_SIZE (50M). With
+        // three raters of 400 units each, the product is 401^3 ~= 64.5M, so the guard must trip
+        // before any enumeration happens.
+        var ann3 = new Rater("Ann3", 2);
+        var units = new ArrayList<AlignableAnnotationUnit>();
+        for (int i = 0; i < 400; i++) {
+            long begin = i * 10L;
+            units.add(unit(ANN1, begin, begin + 5, "a"));
+            units.add(unit(ANN2, begin, begin + 5, "a"));
+            units.add(new AlignableAnnotationUnit(ann3, null, begin, begin + 5,
+                    Map.of("category", "a")));
+        }
+        var set = new AnnotationSet(units);
+
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> BestAlignmentSolver.solve(set, dissimilarity()));
+    }
+
+    @Test
+    void testBruteForceCrossCheck()
+    {
+        // 2 raters x 3 units: compare the ILP optimum against an exhaustive enumeration of all
+        // partial matchings.
+        var a0 = unit(ANN1, 0, 10, "a");
+        var a1 = unit(ANN1, 30, 40, "b");
+        var a2 = unit(ANN1, 55, 65, "a");
+        var b0 = unit(ANN2, 2, 12, "a");
+        var b1 = unit(ANN2, 33, 43, "a");
+        var b2 = unit(ANN2, 200, 210, "b");
+        var aUnits = asList(a0, a1, a2);
+        var bUnits = asList(b0, b1, b2);
+        var set = new AnnotationSet(asList(a0, a1, a2, b0, b1, b2));
+        var d = dissimilarity();
+        double deltaEmpty = 1.0;
+
+        var result = BestAlignmentSolver.solve(set, d);
+
+        double bruteForce = bruteForceBestDisorder(aUnits, bUnits, d, deltaEmpty);
+        assertThat(result.disorder()).isCloseTo(bruteForce, offset(1e-9));
+    }
+
+    /**
+     * Exhaustively enumerates all partial matchings between two raters' units and returns the minimal
+     * alignment disorder. For n = 2 the unitary-alignment disorder divides by C(2,2) = 1, so a matched
+     * pair costs d(a, b) and an unmatched unit costs deltaEmpty; the alignment disorder is the sum
+     * divided by the average number of annotations (numUnits / 2).
+     */
+    private static double bruteForceBestDisorder(List<AlignableAnnotationUnit> aUnits,
+            List<AlignableAnnotationUnit> bUnits, CombinedCategoricalDissimilarity d, double deltaEmpty)
+    {
+        double avg = (aUnits.size() + bUnits.size()) / 2.0;
+        boolean[] usedB = new boolean[bUnits.size()];
+        double best = matchRec(0, aUnits, bUnits, usedB, d, deltaEmpty);
+        return best / avg;
+    }
+
+    private static double matchRec(int aIdx, List<AlignableAnnotationUnit> aUnits,
+            List<AlignableAnnotationUnit> bUnits, boolean[] usedB, CombinedCategoricalDissimilarity d,
+            double deltaEmpty)
+    {
+        if (aIdx == aUnits.size()) {
+            // remaining unmatched b-units become singletons
+            double rest = 0;
+            for (boolean used : usedB) {
+                if (!used) {
+                    rest += deltaEmpty;
+                }
+            }
+            return rest;
+        }
+
+        // Option 1: a-unit stays a singleton.
+        double best = deltaEmpty + matchRec(aIdx + 1, aUnits, bUnits, usedB, d, deltaEmpty);
+
+        // Option 2: a-unit paired with an available b-unit.
+        for (int bIdx = 0; bIdx < bUnits.size(); bIdx++) {
+            if (usedB[bIdx]) {
+                continue;
+            }
+            usedB[bIdx] = true;
+            double cost = d.dissimilarity(aUnits.get(aIdx), bUnits.get(bIdx))
+                    + matchRec(aIdx + 1, aUnits, bUnits, usedB, d, deltaEmpty);
+            usedB[bIdx] = false;
+            best = Math.min(best, cost);
+        }
+
+        return best;
+    }
+}

--- a/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/aligning/disorder/StatisticalContinuumDisorderSamplerTest.java
+++ b/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/aligning/disorder/StatisticalContinuumDisorderSamplerTest.java
@@ -1,0 +1,244 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.statistics.agreement.aligning.disorder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.assertj.core.api.Assertions.offset;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.dkpro.statistics.agreement.aligning.AlignableAnnotationUnit;
+import org.dkpro.statistics.agreement.aligning.GammaAgreement;
+import org.dkpro.statistics.agreement.aligning.data.AnnotationSet;
+import org.dkpro.statistics.agreement.aligning.data.Rater;
+import org.junit.jupiter.api.Test;
+
+class StatisticalContinuumDisorderSamplerTest
+{
+    private static final Rater ANNOTATOR_A = new Rater("A", 0);
+    private static final Rater ANNOTATOR_B = new Rater("B", 1);
+
+    private static AlignableAnnotationUnit unit(Rater aRater, long aBegin, long aEnd, String aCat)
+    {
+        return new AlignableAnnotationUnit(aRater, null, aBegin, aEnd, Map.of("category", aCat));
+    }
+
+    private static AlignableAnnotationUnit unit(Rater aRater, long aBegin, long aEnd,
+            Map<String, String> aFeatures)
+    {
+        return new AlignableAnnotationUnit(aRater, null, aBegin, aEnd, aFeatures);
+    }
+
+    private static GammaAgreement measure(AnnotationSet aSet, long aSeed)
+    {
+        return GammaAgreement.builder().withAnnotationSet(aSet).withSeed(aSeed).build();
+    }
+
+    @Test
+    void statisticsAreExtractedFromReferenceContinuum()
+    {
+        // Rater A: [1,5] a, [10,14] b ; Rater B: [3,7] a
+        var set = new AnnotationSet(List.of( //
+                unit(ANNOTATOR_A, 1, 5, "a"), //
+                unit(ANNOTATOR_A, 10, 14, "b"), //
+                unit(ANNOTATOR_B, 3, 7, "a")));
+
+        var sampler = new StatisticalContinuumDisorderSampler(measure(set, 1));
+
+        // Units per rater: A=2, B=1 -> [2,1]. mean 1.5, population std sqrt(0.25) = 0.5.
+        assertThat(sampler.getAverageNumberOfUnitsPerRater()).isCloseTo(1.5, offset(1e-12));
+        assertThat(sampler.getStandardDeviationOfUnitsPerRater()).isCloseTo(0.5, offset(1e-12));
+
+        // Gaps: seed [0]; A consecutive 10-5=5; B has no consecutive gap; first-starts A=1, B=3.
+        // gaps = [0, 5, 1, 3]. mean 9/4 = 2.25 ; population std = sqrt(14.75/4) = sqrt(3.6875).
+        assertThat(sampler.getAverageGap()).isCloseTo(2.25, offset(1e-12));
+        assertThat(sampler.getStandardDeviationOfGap()).isCloseTo(Math.sqrt(3.6875), offset(1e-12));
+
+        // Durations: all three units span 4 -> mean 4, std 0.
+        assertThat(sampler.getAverageUnitDuration()).isCloseTo(4.0, offset(1e-12));
+        assertThat(sampler.getStandardDeviationOfUnitDuration()).isCloseTo(0.0, offset(1e-12));
+
+        // Categories over all units: a x2, b x1 -> sorted [a, b], weights [2/3, 1/3].
+        assertThat(sampler.getCategories()).containsExactly("a", "b");
+        assertThat(sampler.getCategoryWeights()).containsExactly(2.0 / 3.0, 1.0 / 3.0);
+
+        assertThat(sampler.getFeatureName()).isEqualTo("category");
+    }
+
+    @Test
+    void zeroStandardDeviationDoesNotThrowAndProducesDeterministicMeans()
+    {
+        // Identical counts (2 each) and identical durations (4 each) across both raters.
+        var set = new AnnotationSet(List.of( //
+                unit(ANNOTATOR_A, 0, 4, "a"), //
+                unit(ANNOTATOR_A, 10, 14, "a"), //
+                unit(ANNOTATOR_B, 0, 4, "a"), //
+                unit(ANNOTATOR_B, 10, 14, "a")));
+
+        var sampler = new StatisticalContinuumDisorderSampler(measure(set, 7));
+
+        // std of unit-count and duration are both 0 (would make commons-math NormalDistribution throw).
+        assertThat(sampler.getStandardDeviationOfUnitsPerRater()).isCloseTo(0.0, offset(1e-12));
+        assertThat(sampler.getStandardDeviationOfUnitDuration()).isCloseTo(0.0, offset(1e-12));
+
+        // Sampling must not throw; each rater gets exactly the (deterministic) mean count of 2 units,
+        // each of the deterministic mean duration 4.
+        for (int i = 0; i < 20; i++) {
+            var sample = sampler.sampleContinuum();
+            assertThat(sample.getRaterCount()).isEqualTo(2);
+            assertThat(sample.getUnitsWithRater(ANNOTATOR_A)).hasSize(2);
+            assertThat(sample.getUnitsWithRater(ANNOTATOR_B)).hasSize(2);
+            for (var u : sample.getUnits()) {
+                assertThat(u.getEnd() - u.getBegin()).isEqualTo(4L);
+            }
+        }
+    }
+
+    @Test
+    void sameSeedProducesIdenticalDisorderSequences()
+    {
+        var set = new AnnotationSet(List.of( //
+                unit(ANNOTATOR_A, 1, 5, "a"), //
+                unit(ANNOTATOR_A, 10, 14, "b"), //
+                unit(ANNOTATOR_B, 3, 7, "a"), //
+                unit(ANNOTATOR_B, 12, 16, "b")));
+
+        var s1 = new StatisticalContinuumDisorderSampler(measure(set, 42));
+        var s2 = new StatisticalContinuumDisorderSampler(measure(set, 42));
+
+        var seq1 = new ArrayList<Double>();
+        var seq2 = new ArrayList<Double>();
+        for (int i = 0; i < 10; i++) {
+            seq1.add(s1.sampleDisorder());
+            seq2.add(s2.sampleDisorder());
+        }
+
+        assertThat(seq1).isEqualTo(seq2);
+    }
+
+    @Test
+    void differentSeedsProduceDifferentDisorderSequences()
+    {
+        var set = new AnnotationSet(List.of( //
+                unit(ANNOTATOR_A, 1, 5, "a"), //
+                unit(ANNOTATOR_A, 10, 14, "b"), //
+                unit(ANNOTATOR_B, 3, 7, "a"), //
+                unit(ANNOTATOR_B, 12, 16, "b")));
+
+        var s1 = new StatisticalContinuumDisorderSampler(measure(set, 1));
+        var s2 = new StatisticalContinuumDisorderSampler(measure(set, 2));
+
+        var seq1 = new ArrayList<Double>();
+        var seq2 = new ArrayList<Double>();
+        for (int i = 0; i < 10; i++) {
+            seq1.add(s1.sampleDisorder());
+            seq2.add(s2.sampleDisorder());
+        }
+
+        assertThat(seq1).isNotEqualTo(seq2);
+    }
+
+    @Test
+    void sampledContinuaAreWellFormed()
+    {
+        var set = new AnnotationSet(List.of( //
+                unit(ANNOTATOR_A, 1, 5, "a"), //
+                unit(ANNOTATOR_A, 10, 14, "b"), //
+                unit(ANNOTATOR_A, 20, 25, "c"), //
+                unit(ANNOTATOR_B, 3, 7, "a"), //
+                unit(ANNOTATOR_B, 12, 16, "b")));
+
+        var sampler = new StatisticalContinuumDisorderSampler(measure(set, 123));
+        var referenceCategories = List.of("a", "b", "c");
+
+        for (int i = 0; i < 50; i++) {
+            var sample = sampler.sampleContinuum();
+
+            // Every rater of the reference is present in every sample.
+            assertThat(sample.getRaters()).containsExactlyInAnyOrder(ANNOTATOR_A, ANNOTATOR_B);
+
+            for (var u : sample.getUnits()) {
+                // Well-formed spans.
+                assertThat(u.getBegin()).isLessThan(u.getEnd());
+
+                // The category feature is actually retained on the unit (guards the 4-arg-constructor
+                // trap that silently drops the features map).
+                var category = u.getFeatureValue("category");
+                assertThat(category).isNotNull();
+                assertThat(category).isIn(referenceCategories);
+                assertThat(u.getFeatureNames()).containsExactly("category");
+            }
+        }
+    }
+
+    @Test
+    void featureNameIsAutoDetectedWhenUnique()
+    {
+        var set = new AnnotationSet(List.of( //
+                unit(ANNOTATOR_A, 1, 5, "a"), //
+                unit(ANNOTATOR_B, 3, 7, "b")));
+
+        var sampler = new StatisticalContinuumDisorderSampler(measure(set, 1));
+        assertThat(sampler.getFeatureName()).isEqualTo("category");
+    }
+
+    @Test
+    void multipleFeatureNamesRequireExplicitName()
+    {
+        var set = new AnnotationSet(List.of( //
+                unit(ANNOTATOR_A, 1, 5, Map.of("cat", "a", "pos", "x")), //
+                unit(ANNOTATOR_B, 3, 7, Map.of("cat", "b", "pos", "y"))));
+
+        var m = measure(set, 1);
+
+        // Auto-detection fails with more than one distinct feature name.
+        assertThatExceptionOfType(IllegalArgumentException.class)
+                .isThrownBy(() -> new StatisticalContinuumDisorderSampler(m));
+
+        // ... but an explicit feature name works and is used as the category.
+        var sampler = new StatisticalContinuumDisorderSampler(m, "cat");
+        assertThat(sampler.getFeatureName()).isEqualTo("cat");
+        assertThat(sampler.getCategories()).containsExactly("a", "b");
+
+        var sample = sampler.sampleContinuum();
+        for (var u : sample.getUnits()) {
+            assertThat(u.getFeatureNames()).containsExactly("cat");
+            assertThat(u.getFeatureValue("cat")).isIn("a", "b");
+        }
+    }
+
+    @Test
+    void wiresInThroughSamplerFactory()
+    {
+        var set = new AnnotationSet(List.of( //
+                unit(ANNOTATOR_A, 1, 5, "a"), //
+                unit(ANNOTATOR_A, 10, 14, "b"), //
+                unit(ANNOTATOR_B, 3, 7, "a"), //
+                unit(ANNOTATOR_B, 12, 16, "b")));
+
+        var gamma = GammaAgreement.builder() //
+                .withAnnotationSet(set) //
+                .withDisorderSampler(StatisticalContinuumDisorderSampler::new) //
+                .withSeed(99) //
+                .withNumberOfSamples(30) //
+                .build();
+
+        double agreement = gamma.calculateAgreement();
+        assertThat(Double.isFinite(agreement)).isTrue();
+        assertThat(agreement).isLessThanOrEqualTo(1.0);
+    }
+}

--- a/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/aligning/dissimilarity/AbsoluteCategoricalDissimilarityTest.java
+++ b/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/aligning/dissimilarity/AbsoluteCategoricalDissimilarityTest.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Reference implementation: pygamma-agreement
+ * (https://github.com/bootphon/pygamma-agreement, MIT license).
+ */
+package org.dkpro.statistics.agreement.aligning.dissimilarity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.dkpro.statistics.agreement.aligning.AlignableAnnotationUnit;
+import org.dkpro.statistics.agreement.aligning.data.Rater;
+import org.junit.jupiter.api.Test;
+
+class AbsoluteCategoricalDissimilarityTest
+{
+    private static final Rater ANNOTATOR_1 = new Rater("1", 0);
+    private static final Rater ANNOTATOR_2 = new Rater("2", 1);
+
+    private static AlignableAnnotationUnit unit(Rater aRater, long aBegin, long aEnd, String aLabel)
+    {
+        return new AlignableAnnotationUnit(aRater, null, aBegin, aEnd, Map.of("label", aLabel));
+    }
+
+    @Test
+    void testIdenticalCategoriesAreZero()
+    {
+        var sut = new AbsoluteCategoricalDissimilarity();
+        var u = unit(ANNOTATOR_1, 0, 10, "A");
+        var v = unit(ANNOTATOR_2, 5, 20, "A");
+
+        assertThat(sut.dissimilarity(u, v)).isEqualTo(0.0);
+    }
+
+    @Test
+    void testDifferentCategoriesCostDeltaEmpty()
+    {
+        var sut = new AbsoluteCategoricalDissimilarity();
+        var u = unit(ANNOTATOR_1, 0, 10, "A");
+        var v = unit(ANNOTATOR_2, 0, 10, "B");
+
+        assertThat(sut.dissimilarity(u, v)).isEqualTo(1.0);
+    }
+
+    @Test
+    void testDeltaEmptyScaling()
+    {
+        var sut = new AbsoluteCategoricalDissimilarity(3.0);
+        var u = unit(ANNOTATOR_1, 0, 10, "A");
+        var v = unit(ANNOTATOR_2, 0, 10, "B");
+
+        assertThat(sut.dissimilarity(u, v)).isEqualTo(3.0);
+    }
+
+    @Test
+    void testSelfIsZeroAndSymmetric()
+    {
+        var sut = new AbsoluteCategoricalDissimilarity();
+        var u = unit(ANNOTATOR_1, 0, 10, "A");
+        var v = unit(ANNOTATOR_2, 0, 10, "B");
+
+        assertThat(sut.dissimilarity(u, u)).isEqualTo(0.0);
+        assertThat(sut.dissimilarity(u, v)).isEqualTo(sut.dissimilarity(v, u));
+    }
+
+    @Test
+    void testNullUnitsCostDeltaEmpty()
+    {
+        var sut = new AbsoluteCategoricalDissimilarity(2.0);
+        var u = unit(ANNOTATOR_1, 0, 10, "A");
+
+        assertThat(sut.dissimilarity(u, null)).isEqualTo(2.0);
+        assertThat(sut.dissimilarity(null, u)).isEqualTo(2.0);
+        assertThat(sut.dissimilarity(null, null)).isEqualTo(2.0);
+    }
+}

--- a/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/aligning/dissimilarity/CombinedCategoricalDissimilarityTest.java
+++ b/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/aligning/dissimilarity/CombinedCategoricalDissimilarityTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Reference implementation: pygamma-agreement
+ * (https://github.com/bootphon/pygamma-agreement, MIT license).
+ */
+package org.dkpro.statistics.agreement.aligning.dissimilarity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.dkpro.statistics.agreement.aligning.AlignableAnnotationUnit;
+import org.dkpro.statistics.agreement.aligning.data.Rater;
+import org.junit.jupiter.api.Test;
+
+class CombinedCategoricalDissimilarityTest
+{
+    private static final Rater ANNOTATOR_1 = new Rater("1", 0);
+    private static final Rater ANNOTATOR_2 = new Rater("2", 1);
+
+    private static AlignableAnnotationUnit unit(Rater aRater, long aBegin, long aEnd, String aLabel)
+    {
+        return new AlignableAnnotationUnit(aRater, null, aBegin, aEnd, Map.of("label", aLabel));
+    }
+
+    @Test
+    void testDefaultsWeightBothEqually()
+    {
+        var sut = new CombinedCategoricalDissimilarity();
+        var u = unit(ANNOTATOR_1, 0, 10, "A");
+        var v = unit(ANNOTATOR_2, 5, 15, "B");
+
+        // positional = 0.25, categorical = 1.0 (different), alpha=beta=1 -> 0.25 + 1.0 = 1.25
+        assertThat(sut.dissimilarity(u, v)).isEqualTo(1.25);
+    }
+
+    @Test
+    void testAlphaBetaWeighting()
+    {
+        var sut = CombinedCategoricalDissimilarity.builder() //
+                .withAlpha(3.0) //
+                .withBeta(2.0) //
+                .build();
+        var u = unit(ANNOTATOR_1, 0, 10, "A");
+        var v = unit(ANNOTATOR_2, 5, 15, "B");
+
+        // 3 * 0.25 (positional) + 2 * 1.0 (categorical) = 0.75 + 2.0 = 2.75
+        assertThat(sut.dissimilarity(u, v)).isEqualTo(2.75);
+    }
+
+    @Test
+    void testConstructorMatchesBuilder()
+    {
+        var sut = new CombinedCategoricalDissimilarity(3.0, 2.0, 1.0,
+                new PositionalSporadicDissimilarity(1.0), new AbsoluteCategoricalDissimilarity(1.0));
+        var u = unit(ANNOTATOR_1, 0, 10, "A");
+        var v = unit(ANNOTATOR_2, 5, 15, "B");
+
+        assertThat(sut.dissimilarity(u, v)).isEqualTo(2.75);
+    }
+
+    @Test
+    void testSameCategorySameSpanIsZero()
+    {
+        var sut = new CombinedCategoricalDissimilarity();
+        var u = unit(ANNOTATOR_1, 0, 10, "A");
+        var v = unit(ANNOTATOR_2, 0, 10, "A");
+
+        assertThat(sut.dissimilarity(u, v)).isEqualTo(0.0);
+    }
+
+    @Test
+    void testSelfIsZeroAndSymmetric()
+    {
+        var sut = CombinedCategoricalDissimilarity.builder().withAlpha(3.0).withBeta(2.0).build();
+        var u = unit(ANNOTATOR_1, 0, 10, "A");
+        var v = unit(ANNOTATOR_2, 5, 15, "B");
+
+        assertThat(sut.dissimilarity(u, u)).isEqualTo(0.0);
+        assertThat(sut.dissimilarity(u, v)).isEqualTo(sut.dissimilarity(v, u));
+    }
+
+    @Test
+    void testNullUnitsCostDeltaEmpty()
+    {
+        var sut = CombinedCategoricalDissimilarity.builder() //
+                .withAlpha(3.0) //
+                .withBeta(2.0) //
+                .withDeltaEmpty(1.5) //
+                .build();
+        var u = unit(ANNOTATOR_1, 0, 10, "A");
+
+        // Any pair involving an empty unit costs the combined deltaEmpty, NOT alpha/beta-weighted.
+        assertThat(sut.dissimilarity(u, null)).isEqualTo(1.5);
+        assertThat(sut.dissimilarity(null, u)).isEqualTo(1.5);
+        assertThat(sut.dissimilarity(null, null)).isEqualTo(1.5);
+    }
+}

--- a/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/aligning/dissimilarity/PositionalSporadicDissimilarityTest.java
+++ b/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/aligning/dissimilarity/PositionalSporadicDissimilarityTest.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Reference implementation: pygamma-agreement
+ * (https://github.com/bootphon/pygamma-agreement, MIT license).
+ */
+package org.dkpro.statistics.agreement.aligning.dissimilarity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+
+import org.dkpro.statistics.agreement.aligning.AlignableAnnotationUnit;
+import org.dkpro.statistics.agreement.aligning.data.Rater;
+import org.junit.jupiter.api.Test;
+
+class PositionalSporadicDissimilarityTest
+{
+    private static final Rater ANNOTATOR_1 = new Rater("1", 0);
+    private static final Rater ANNOTATOR_2 = new Rater("2", 1);
+
+    private static AlignableAnnotationUnit unit(Rater aRater, long aBegin, long aEnd)
+    {
+        return new AlignableAnnotationUnit(aRater, null, aBegin, aEnd, null);
+    }
+
+    @Test
+    void testIdenticalSpansAreZero()
+    {
+        var sut = new PositionalSporadicDissimilarity();
+        var u = unit(ANNOTATOR_1, 0, 10);
+        var v = unit(ANNOTATOR_2, 0, 10);
+
+        assertThat(sut.dissimilarity(u, v)).isEqualTo(0.0);
+    }
+
+    @Test
+    void testHandComputedShiftedSpan()
+    {
+        var sut = new PositionalSporadicDissimilarity();
+        var u = unit(ANNOTATOR_1, 0, 10);
+        var v = unit(ANNOTATOR_2, 5, 15);
+
+        // ((|0-5| + |10-15|) / (10 + 10))^2 = (10/20)^2 = 0.25
+        assertThat(sut.dissimilarity(u, v)).isEqualTo(0.25);
+    }
+
+    @Test
+    void testHandComputedAsymmetricSpans()
+    {
+        var sut = new PositionalSporadicDissimilarity();
+        var u = unit(ANNOTATOR_1, 0, 10);
+        var v = unit(ANNOTATOR_2, 0, 20);
+
+        // ((|0-0| + |10-20|) / (10 + 20))^2 = (10/30)^2 = 0.1111...
+        assertThat(sut.dissimilarity(u, v)).isCloseTo(1.0 / 9.0, offset(1e-12));
+    }
+
+    @Test
+    void testDeltaEmptyScaling()
+    {
+        var sut = new PositionalSporadicDissimilarity(2.0);
+        var u = unit(ANNOTATOR_1, 0, 10);
+        var v = unit(ANNOTATOR_2, 5, 15);
+
+        // 0.25 * deltaEmpty(2.0) = 0.5
+        assertThat(sut.dissimilarity(u, v)).isEqualTo(0.5);
+    }
+
+    @Test
+    void testSelfIsZeroAndSymmetric()
+    {
+        var sut = new PositionalSporadicDissimilarity();
+        var u = unit(ANNOTATOR_1, 2, 12);
+        var v = unit(ANNOTATOR_2, 7, 20);
+
+        assertThat(sut.dissimilarity(u, u)).isEqualTo(0.0);
+        assertThat(sut.dissimilarity(u, v)).isEqualTo(sut.dissimilarity(v, u));
+    }
+
+    @Test
+    void testNullUnitsCostDeltaEmpty()
+    {
+        var sut = new PositionalSporadicDissimilarity(1.5);
+        var u = unit(ANNOTATOR_1, 0, 10);
+
+        assertThat(sut.dissimilarity(u, null)).isEqualTo(1.5);
+        assertThat(sut.dissimilarity(null, u)).isEqualTo(1.5);
+        assertThat(sut.dissimilarity(null, null)).isEqualTo(1.5);
+    }
+}

--- a/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/aligning/dissimilarity/PrecomputedCategoricalDissimilarityTest.java
+++ b/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/aligning/dissimilarity/PrecomputedCategoricalDissimilarityTest.java
@@ -1,0 +1,162 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Reference implementation: pygamma-agreement
+ * (https://github.com/bootphon/pygamma-agreement, MIT license).
+ */
+package org.dkpro.statistics.agreement.aligning.dissimilarity;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import java.util.List;
+import java.util.Map;
+
+import org.dkpro.statistics.agreement.aligning.AlignableAnnotationUnit;
+import org.dkpro.statistics.agreement.aligning.data.Rater;
+import org.junit.jupiter.api.Test;
+
+class PrecomputedCategoricalDissimilarityTest
+{
+    private static final Rater ANNOTATOR_1 = new Rater("1", 0);
+    private static final Rater ANNOTATOR_2 = new Rater("2", 1);
+
+    private static AlignableAnnotationUnit unit(Rater aRater, String aLabel)
+    {
+        return new AlignableAnnotationUnit(aRater, null, 0, 10, Map.of("label", aLabel));
+    }
+
+    // Matrix laid out in alphabetical category order: a, b, c.
+    //        a    b    c
+    //  a [ 0.0  0.5  0.9 ]
+    //  b [ 0.5  0.0  0.2 ]
+    //  c [ 0.9  0.2  0.0 ]
+    private static double[][] matrix()
+    {
+        return new double[][] { //
+                { 0.0, 0.5, 0.9 }, //
+                { 0.5, 0.0, 0.2 }, //
+                { 0.9, 0.2, 0.0 } };
+    }
+
+    @Test
+    void testMatrixLookupWithNonAlphabeticalCategoryInput()
+    {
+        // Categories passed in non-alphabetical order; the matrix must still be interpreted in
+        // sorted order (a, b, c).
+        var categories = asList("c", "a", "b");
+        var sut = new PrecomputedCategoricalDissimilarity("label", categories, matrix(), 1.0);
+
+        // a<->c -> index 0,2 -> 0.9
+        assertThat(sut.dissimilarity(unit(ANNOTATOR_1, "a"), unit(ANNOTATOR_2, "c")))
+                .isEqualTo(0.9);
+        // b<->c -> index 1,2 -> 0.2
+        assertThat(sut.dissimilarity(unit(ANNOTATOR_1, "b"), unit(ANNOTATOR_2, "c")))
+                .isEqualTo(0.2);
+        // a<->b -> index 0,1 -> 0.5
+        assertThat(sut.dissimilarity(unit(ANNOTATOR_1, "a"), unit(ANNOTATOR_2, "b")))
+                .isEqualTo(0.5);
+    }
+
+    @Test
+    void testDeltaEmptyScaling()
+    {
+        var sut = new PrecomputedCategoricalDissimilarity("label", asList("a", "b", "c"), matrix(),
+                2.0);
+
+        // a<->c -> 0.9 * deltaEmpty(2.0) = 1.8
+        assertThat(sut.dissimilarity(unit(ANNOTATOR_1, "a"), unit(ANNOTATOR_2, "c")))
+                .isEqualTo(1.8);
+    }
+
+    @Test
+    void testSelfIsZeroAndSymmetric()
+    {
+        var sut = new PrecomputedCategoricalDissimilarity("label", asList("a", "b", "c"), matrix(),
+                1.0);
+
+        assertThat(sut.dissimilarity(unit(ANNOTATOR_1, "b"), unit(ANNOTATOR_2, "b")))
+                .isEqualTo(0.0);
+        assertThat(sut.dissimilarity(unit(ANNOTATOR_1, "a"), unit(ANNOTATOR_2, "c")))
+                .isEqualTo(sut.dissimilarity(unit(ANNOTATOR_1, "c"), unit(ANNOTATOR_2, "a")));
+    }
+
+    @Test
+    void testNullUnitsCostDeltaEmpty()
+    {
+        var sut = new PrecomputedCategoricalDissimilarity("label", asList("a", "b", "c"), matrix(),
+                1.5);
+        var u = unit(ANNOTATOR_1, "a");
+
+        assertThat(sut.dissimilarity(u, null)).isEqualTo(1.5);
+        assertThat(sut.dissimilarity(null, u)).isEqualTo(1.5);
+        assertThat(sut.dissimilarity(null, null)).isEqualTo(1.5);
+    }
+
+    @Test
+    void testUnknownCategoryThrows()
+    {
+        var sut = new PrecomputedCategoricalDissimilarity("label", asList("a", "b", "c"), matrix(),
+                1.0);
+
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(
+                () -> sut.dissimilarity(unit(ANNOTATOR_1, "z"), unit(ANNOTATOR_2, "a")));
+    }
+
+    @Test
+    void testNonSquareMatrixThrows()
+    {
+        double[][] nonSquare = { { 0.0, 0.5 }, { 0.5, 0.0 }, { 0.9, 0.2 } };
+        List<String> categories = asList("a", "b", "c");
+
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(
+                () -> new PrecomputedCategoricalDissimilarity("label", categories, nonSquare, 1.0));
+    }
+
+    @Test
+    void testDimensionMismatchThrows()
+    {
+        double[][] twoByTwo = { { 0.0, 0.5 }, { 0.5, 0.0 } };
+        List<String> categories = asList("a", "b", "c");
+
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(
+                () -> new PrecomputedCategoricalDissimilarity("label", categories, twoByTwo, 1.0));
+    }
+
+    @Test
+    void testAsymmetricMatrixThrows()
+    {
+        double[][] asymmetric = { //
+                { 0.0, 0.5, 0.9 }, //
+                { 0.4, 0.0, 0.2 }, //
+                { 0.9, 0.2, 0.0 } };
+        List<String> categories = asList("a", "b", "c");
+
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(
+                () -> new PrecomputedCategoricalDissimilarity("label", categories, asymmetric, 1.0));
+    }
+
+    @Test
+    void testNonZeroDiagonalThrows()
+    {
+        double[][] nonZeroDiag = { //
+                { 0.1, 0.5, 0.9 }, //
+                { 0.5, 0.0, 0.2 }, //
+                { 0.9, 0.2, 0.0 } };
+        List<String> categories = asList("a", "b", "c");
+
+        assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(
+                () -> new PrecomputedCategoricalDissimilarity("label", categories, nonZeroDiag, 1.0));
+    }
+}

--- a/dkpro-statistics-agreement/src/test/resources/pygamma/fixture_01_two_annotators_simple.json
+++ b/dkpro-statistics-agreement/src/test/resources/pygamma/fixture_01_two_annotators_simple.json
@@ -1,0 +1,978 @@
+{
+  "metadata": {
+    "pygammaVersion": "0.5.9",
+    "pygammaRepo": "https://github.com/bootphon/pygamma-agreement",
+    "pygammaCommit": "44587ef",
+    "solver": "GLPK_MI",
+    "seed": 1,
+    "description": "2 annotators, 3 units each, small positional offsets, nominal categories."
+  },
+  "params": {
+    "alpha": 1.0,
+    "beta": 1.0,
+    "deltaEmpty": 1.0
+  },
+  "continuum": [
+    {
+      "annotator": "Ann1",
+      "start": 1,
+      "end": 5,
+      "category": "a"
+    },
+    {
+      "annotator": "Ann1",
+      "start": 6,
+      "end": 10,
+      "category": "b"
+    },
+    {
+      "annotator": "Ann1",
+      "start": 11,
+      "end": 15,
+      "category": "a"
+    },
+    {
+      "annotator": "Ann2",
+      "start": 2,
+      "end": 6,
+      "category": "a"
+    },
+    {
+      "annotator": "Ann2",
+      "start": 7,
+      "end": 11,
+      "category": "b"
+    },
+    {
+      "annotator": "Ann2",
+      "start": 12,
+      "end": 16,
+      "category": "a"
+    }
+  ],
+  "tier1": {
+    "pairDissimilarities": [
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 0,
+        "annotatorB": "Ann2",
+        "unitIndexB": 0,
+        "positional": 0.0625,
+        "categorical": 0.0,
+        "combined": 0.0625
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 0,
+        "annotatorB": "Ann2",
+        "unitIndexB": 1,
+        "positional": 2.25,
+        "categorical": 1.0,
+        "combined": 3.25
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 0,
+        "annotatorB": "Ann2",
+        "unitIndexB": 2,
+        "positional": 7.5625,
+        "categorical": 0.0,
+        "combined": 7.5625
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 1,
+        "annotatorB": "Ann2",
+        "unitIndexB": 0,
+        "positional": 1.0,
+        "categorical": 1.0,
+        "combined": 2.0
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 1,
+        "annotatorB": "Ann2",
+        "unitIndexB": 1,
+        "positional": 0.0625,
+        "categorical": 0.0,
+        "combined": 0.0625
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 1,
+        "annotatorB": "Ann2",
+        "unitIndexB": 2,
+        "positional": 2.25,
+        "categorical": 1.0,
+        "combined": 3.25
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 2,
+        "annotatorB": "Ann2",
+        "unitIndexB": 0,
+        "positional": 5.0625,
+        "categorical": 0.0,
+        "combined": 5.0625
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 2,
+        "annotatorB": "Ann2",
+        "unitIndexB": 1,
+        "positional": 1.0,
+        "categorical": 1.0,
+        "combined": 2.0
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 2,
+        "annotatorB": "Ann2",
+        "unitIndexB": 2,
+        "positional": 0.0625,
+        "categorical": 0.0,
+        "combined": 0.0625
+      }
+    ],
+    "bestAlignmentDisorder": 0.0625
+  },
+  "tier2": {
+    "sampledContinua": [
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 0.6730024422799801,
+            "end": 4.67300244227998,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 5.099476589298938,
+            "end": 9.099476589298938,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 10.706344204657507,
+            "end": 14.706344204657507,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 0.5403605847111163,
+            "end": 4.540360584711117,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 5.368021339993954,
+            "end": 9.368021339993954,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 10.758209708920607,
+            "end": 14.758209708920607,
+            "category": "b"
+          }
+        ],
+        "bestAlignmentDisorder": 0.3352583348751068,
+        "scaled": {
+          "scale": 1000000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 673002,
+              "end": 4673002,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 5099477,
+              "end": 9099477,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 10706344,
+              "end": 14706344,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 540361,
+              "end": 4540361,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 5368021,
+              "end": 9368021,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 10758210,
+              "end": 14758210,
+              "category": "b"
+            }
+          ],
+          "bestAlignmentDisorder": 0.3352583348751068
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 0.5307649380061162,
+            "end": 4.530764938006116,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 5.8422927736524075,
+            "end": 9.842292773652407,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 10.23849876338424,
+            "end": 14.23849876338424,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 1.466861684145309,
+            "end": 5.466861684145309,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 6.097153461168935,
+            "end": 10.097153461168935,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 10.531491535173489,
+            "end": 14.531491535173489,
+            "category": "a"
+          }
+        ],
+        "bestAlignmentDisorder": 0.6880640983581543,
+        "scaled": {
+          "scale": 1000000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 530765,
+              "end": 4530765,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 5842293,
+              "end": 9842293,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 10238499,
+              "end": 14238499,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1466862,
+              "end": 5466862,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 6097153,
+              "end": 10097153,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 10531492,
+              "end": 14531492,
+              "category": "a"
+            }
+          ],
+          "bestAlignmentDisorder": 0.6880640983581543
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 0.9932304871292233,
+            "end": 4.993230487129224,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 6.118530948173951,
+            "end": 10.118530948173952,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 11.282315254393026,
+            "end": 15.282315254393026,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 2.091510277887639,
+            "end": 6.0915102778876395,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 7.155737939621912,
+            "end": 11.155737939621911,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 11.933316944328883,
+            "end": 15.933316944328883,
+            "category": "a"
+          }
+        ],
+        "bestAlignmentDisorder": 0.3897045850753784,
+        "scaled": {
+          "scale": 1000000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 993230,
+              "end": 4993230,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 6118531,
+              "end": 10118531,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 11282315,
+              "end": 15282315,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 2091510,
+              "end": 6091510,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 7155738,
+              "end": 11155738,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 11933317,
+              "end": 15933317,
+              "category": "a"
+            }
+          ],
+          "bestAlignmentDisorder": 0.3897045850753784
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 1.3135632852199675,
+            "end": 5.313563285219967,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 6.8112582824128305,
+            "end": 10.81125828241283,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 12.171374672088966,
+            "end": 16.171374672088966,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 1.0428957434897315,
+            "end": 5.042895743489732,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 7.211134938376341,
+            "end": 11.21113493837634,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 12.38488544194431,
+            "end": 16.38488544194431,
+            "category": "a"
+          }
+        ],
+        "bestAlignmentDisorder": 0.3391406238079071,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 131356,
+              "end": 531356,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 681126,
+              "end": 1081126,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1217137,
+              "end": 1617137,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 104290,
+              "end": 504290,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 721113,
+              "end": 1121113,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1238489,
+              "end": 1638489,
+              "category": "a"
+            }
+          ],
+          "bestAlignmentDisorder": 0.33914053440093994
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": -0.08091201667587522,
+            "end": 3.9190879833241246,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 5.361659045834541,
+            "end": 9.361659045834541,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 10.368676741799392,
+            "end": 14.368676741799392,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 0.7865821850333332,
+            "end": 4.786582185033334,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 5.892577843977267,
+            "end": 9.892577843977268,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 11.203629938609147,
+            "end": 15.203629938609147,
+            "category": "a"
+          }
+        ],
+        "bestAlignmentDisorder": 0.36940762400627136,
+        "scaled": {
+          "scale": 1000000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": -80912,
+              "end": 3919088,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 5361659,
+              "end": 9361659,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 10368677,
+              "end": 14368677,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 786582,
+              "end": 4786582,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 5892578,
+              "end": 9892578,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 11203630,
+              "end": 15203630,
+              "category": "a"
+            }
+          ],
+          "bestAlignmentDisorder": 0.36940765380859375
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 1.0989702681696283,
+            "end": 5.098970268169628,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 5.75755450428274,
+            "end": 9.75755450428274,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 11.00472881351123,
+            "end": 15.00472881351123,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 1.5340153501415403,
+            "end": 5.534015350141541,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 5.948760350786789,
+            "end": 9.948760350786788,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 10.821449192498056,
+            "end": 14.821449192498056,
+            "category": "b"
+          }
+        ],
+        "bestAlignmentDisorder": 0.3387378454208374,
+        "scaled": {
+          "scale": 1000000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 1098970,
+              "end": 5098970,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 5757555,
+              "end": 9757555,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 11004729,
+              "end": 15004729,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1534015,
+              "end": 5534015,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 5948760,
+              "end": 9948760,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 10821449,
+              "end": 14821449,
+              "category": "b"
+            }
+          ],
+          "bestAlignmentDisorder": 0.3387378454208374
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 1.0174332085073556,
+            "end": 5.017433208507356,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 6.1858929895425305,
+            "end": 10.18589298954253,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 11.51866680220116,
+            "end": 15.51866680220116,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 0.8267111925297673,
+            "end": 4.826711192529768,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 5.81355287613084,
+            "end": 9.81355287613084,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 9.843361016020864,
+            "end": 13.843361016020864,
+            "category": "b"
+          }
+        ],
+        "bestAlignmentDisorder": 0.3954513370990753,
+        "scaled": {
+          "scale": 1000000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 1017433,
+              "end": 5017433,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 6185893,
+              "end": 10185893,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 11518667,
+              "end": 15518667,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 826711,
+              "end": 4826711,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 5813553,
+              "end": 9813553,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 9843361,
+              "end": 13843361,
+              "category": "b"
+            }
+          ],
+          "bestAlignmentDisorder": 0.39545130729675293
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 1.6607574679725776,
+            "end": 5.660757467972577,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 6.841432319587417,
+            "end": 10.841432319587417,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 11.782183463051629,
+            "end": 15.782183463051629,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 0.9498206139347932,
+            "end": 4.949820613934794,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 6.228080370647693,
+            "end": 10.228080370647692,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 11.14135697013314,
+            "end": 15.14135697013314,
+            "category": "a"
+          }
+        ],
+        "bestAlignmentDisorder": 0.36025604605674744,
+        "scaled": {
+          "scale": 1000000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 1660757,
+              "end": 5660757,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 6841432,
+              "end": 10841432,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 11782183,
+              "end": 15782183,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 949821,
+              "end": 4949821,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 6228080,
+              "end": 10228080,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 11141357,
+              "end": 15141357,
+              "category": "a"
+            }
+          ],
+          "bestAlignmentDisorder": 0.36025598645210266
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 1.4011118936317222,
+            "end": 5.401111893631722,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 6.4747162864252115,
+            "end": 10.474716286425211,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 11.535233874639086,
+            "end": 15.535233874639086,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 1.4154022876729537,
+            "end": 5.415402287672954,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 6.651321506321205,
+            "end": 10.651321506321205,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 11.427261405118461,
+            "end": 15.427261405118461,
+            "category": "b"
+          }
+        ],
+        "bestAlignmentDisorder": 0.3342302143573761,
+        "scaled": {
+          "scale": 1000000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 1401112,
+              "end": 5401112,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 6474716,
+              "end": 10474716,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 11535234,
+              "end": 15535234,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1415402,
+              "end": 5415402,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 6651322,
+              "end": 10651322,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 11427261,
+              "end": 15427261,
+              "category": "b"
+            }
+          ],
+          "bestAlignmentDisorder": 0.3342302143573761
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 0.4670667436443721,
+            "end": 4.467066743644372,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 5.3085053780744325,
+            "end": 9.308505378074432,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 10.657890791996444,
+            "end": 14.657890791996444,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 0.9553142100871482,
+            "end": 4.955314210087148,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 5.978656268786991,
+            "end": 9.978656268786992,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 10.661139533219394,
+            "end": 14.661139533219394,
+            "category": "b"
+          }
+        ],
+        "bestAlignmentDisorder": 0.34765625,
+        "scaled": {
+          "scale": 1000000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 467067,
+              "end": 4467067,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 5308505,
+              "end": 9308505,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 10657891,
+              "end": 14657891,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 955314,
+              "end": 4955314,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 5978656,
+              "end": 9978656,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 10661140,
+              "end": 14661140,
+              "category": "b"
+            }
+          ],
+          "bestAlignmentDisorder": 0.3476562201976776
+        }
+      }
+    ]
+  },
+  "tier3": {
+    "expectedDisorder": 0.5369704365730286,
+    "gamma": 0.8836062550544739,
+    "nSamples": 30
+  }
+}

--- a/dkpro-statistics-agreement/src/test/resources/pygamma/fixture_02_unequal_counts.json
+++ b/dkpro-statistics-agreement/src/test/resources/pygamma/fixture_02_unequal_counts.json
@@ -1,0 +1,777 @@
+{
+  "metadata": {
+    "pygammaVersion": "0.5.9",
+    "pygammaRepo": "https://github.com/bootphon/pygamma-agreement",
+    "pygammaCommit": "44587ef",
+    "solver": "GLPK_MI",
+    "seed": 2,
+    "description": "2 annotators with unequal unit counts (4 vs 2), forcing empty units in the best alignment."
+  },
+  "params": {
+    "alpha": 1.0,
+    "beta": 1.0,
+    "deltaEmpty": 1.0
+  },
+  "continuum": [
+    {
+      "annotator": "Ann1",
+      "start": 1,
+      "end": 5,
+      "category": "a"
+    },
+    {
+      "annotator": "Ann1",
+      "start": 6,
+      "end": 10,
+      "category": "b"
+    },
+    {
+      "annotator": "Ann1",
+      "start": 20,
+      "end": 24,
+      "category": "a"
+    },
+    {
+      "annotator": "Ann1",
+      "start": 30,
+      "end": 34,
+      "category": "b"
+    },
+    {
+      "annotator": "Ann2",
+      "start": 2,
+      "end": 6,
+      "category": "a"
+    },
+    {
+      "annotator": "Ann2",
+      "start": 31,
+      "end": 35,
+      "category": "b"
+    }
+  ],
+  "tier1": {
+    "pairDissimilarities": [
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 0,
+        "annotatorB": "Ann2",
+        "unitIndexB": 0,
+        "positional": 0.0625,
+        "categorical": 0.0,
+        "combined": 0.0625
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 0,
+        "annotatorB": "Ann2",
+        "unitIndexB": 1,
+        "positional": 56.25,
+        "categorical": 1.0,
+        "combined": 57.25
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 1,
+        "annotatorB": "Ann2",
+        "unitIndexB": 0,
+        "positional": 1.0,
+        "categorical": 1.0,
+        "combined": 2.0
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 1,
+        "annotatorB": "Ann2",
+        "unitIndexB": 1,
+        "positional": 39.0625,
+        "categorical": 0.0,
+        "combined": 39.0625
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 2,
+        "annotatorB": "Ann2",
+        "unitIndexB": 0,
+        "positional": 20.25,
+        "categorical": 0.0,
+        "combined": 20.25
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 2,
+        "annotatorB": "Ann2",
+        "unitIndexB": 1,
+        "positional": 7.5625,
+        "categorical": 1.0,
+        "combined": 8.5625
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 3,
+        "annotatorB": "Ann2",
+        "unitIndexB": 0,
+        "positional": 49.0,
+        "categorical": 1.0,
+        "combined": 50.0
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 3,
+        "annotatorB": "Ann2",
+        "unitIndexB": 1,
+        "positional": 0.0625,
+        "categorical": 0.0,
+        "combined": 0.0625
+      }
+    ],
+    "bestAlignmentDisorder": 0.7083333134651184
+  },
+  "tier2": {
+    "sampledContinua": [
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 5.96374852287338,
+            "end": 9.96374852287338,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 29.94267423439825,
+            "end": 33.942674234398254,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": -2.311221602288797,
+            "end": 1.6887783977112032,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": -1.0584244003744652,
+            "end": 2.941575599625535,
+            "category": "b"
+          }
+        ],
+        "bestAlignmentDisorder": 2.0,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 596375,
+              "end": 996375,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 2994267,
+              "end": 3394267,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": -231122,
+              "end": 168878,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": -105842,
+              "end": 294158,
+              "category": "b"
+            }
+          ],
+          "bestAlignmentDisorder": 2.0
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 1.5036681137022987,
+            "end": 5.5036681137022985,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 21.638979871703626,
+            "end": 25.638979871703626,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 25.187437860841495,
+            "end": 29.187437860841495,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": -5.049272967793716,
+            "end": -1.0492729677937156,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 0.11160041653499575,
+            "end": 4.111600416534996,
+            "category": "a"
+          }
+        ],
+        "bestAlignmentDisorder": 1.6484463214874268,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 150367,
+              "end": 550367,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 2163898,
+              "end": 2563898,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 2518744,
+              "end": 2918744,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": -504927,
+              "end": -104927,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 11160,
+              "end": 411160,
+              "category": "a"
+            }
+          ],
+          "bestAlignmentDisorder": 1.6484464406967163
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": -21.636978150336315,
+            "end": -17.636978150336315,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": -3.21950748238052,
+            "end": 0.7804925176194799,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 0.02359255537234972,
+            "end": 4.02359255537235,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": -9.003813316864731,
+            "end": -5.003813316864731,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 3.0368936096251122,
+            "end": 7.036893609625112,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 6.615939425060552,
+            "end": 10.615939425060553,
+            "category": "a"
+          }
+        ],
+        "bestAlignmentDisorder": 1.8558330535888672,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": -2163698,
+              "end": -1763698,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": -321951,
+              "end": 78049,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 2359,
+              "end": 402359,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": -900381,
+              "end": -500381,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 303689,
+              "end": 703689,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 661594,
+              "end": 1061594,
+              "category": "a"
+            }
+          ],
+          "bestAlignmentDisorder": 1.8558326959609985
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 15.455175372186485,
+            "end": 19.455175372186485,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 30.343073593957854,
+            "end": 34.343073593957854,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 8.073774275922348,
+            "end": 12.073774275922348,
+            "category": "a"
+          }
+        ],
+        "bestAlignmentDisorder": 2.0,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 1545518,
+              "end": 1945518,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 3034307,
+              "end": 3434307,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 807377,
+              "end": 1207377,
+              "category": "a"
+            }
+          ],
+          "bestAlignmentDisorder": 2.0
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": -5.46270206180098,
+            "end": -1.4627020618009796,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 11.040048521608725,
+            "end": 15.040048521608725,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": -2.6481626814218244,
+            "end": 1.3518373185781756,
+            "category": "a"
+          }
+        ],
+        "bestAlignmentDisorder": 0.9967346787452698,
+        "scaled": {
+          "scale": 1000000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": -5462702,
+              "end": -1462702,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 11040049,
+              "end": 15040049,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": -2648163,
+              "end": 1351837,
+              "category": "a"
+            }
+          ],
+          "bestAlignmentDisorder": 0.9967345595359802
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": -2.037116042990116,
+            "end": 1.962883957009884,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 4.863356922876492,
+            "end": 8.863356922876491,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 5.830236812404399,
+            "end": 9.830236812404399,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 27.553604373104704,
+            "end": 31.553604373104704,
+            "category": "a"
+          }
+        ],
+        "bestAlignmentDisorder": 2.0,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": -203712,
+              "end": 196288,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 486336,
+              "end": 886336,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 583024,
+              "end": 983024,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 2755360,
+              "end": 3155360,
+              "category": "a"
+            }
+          ],
+          "bestAlignmentDisorder": 2.0
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 9.62430859454555,
+            "end": 13.62430859454555,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 25.3614630700306,
+            "end": 29.3614630700306,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 44.38833012293431,
+            "end": 48.38833012293431,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 16.023955084826607,
+            "end": 20.023955084826607,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 29.28320836200665,
+            "end": 33.28320836200665,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 54.873549721787896,
+            "end": 58.873549721787896,
+            "category": "a"
+          }
+        ],
+        "bestAlignmentDisorder": 1.6537517309188843,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 962431,
+              "end": 1362431,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 2536146,
+              "end": 2936146,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 4438833,
+              "end": 4838833,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1602396,
+              "end": 2002396,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 2928321,
+              "end": 3328321,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 5487355,
+              "end": 5887355,
+              "category": "a"
+            }
+          ],
+          "bestAlignmentDisorder": 1.6537526845932007
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 6.247959056826286,
+            "end": 10.247959056826286,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 24.18654025898983,
+            "end": 28.18654025898983,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 4.429397427054209,
+            "end": 8.429397427054209,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 6.420013734141735,
+            "end": 10.420013734141735,
+            "category": "b"
+          }
+        ],
+        "bestAlignmentDisorder": 1.500925064086914,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 624796,
+              "end": 1024796,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 2418654,
+              "end": 2818654,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 442940,
+              "end": 842940,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 642001,
+              "end": 1042001,
+              "category": "b"
+            }
+          ],
+          "bestAlignmentDisorder": 1.500925064086914
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": -0.4019253504164786,
+            "end": 3.5980746495835216,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 14.777656501628444,
+            "end": 18.777656501628442,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 16.99672171645016,
+            "end": 20.99672171645016,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 5.483331713075393,
+            "end": 9.483331713075394,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 18.34716043296163,
+            "end": 22.34716043296163,
+            "category": "a"
+          }
+        ],
+        "bestAlignmentDisorder": 1.5185339450836182,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": -40193,
+              "end": 359807,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1477766,
+              "end": 1877766,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1699672,
+              "end": 2099672,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 548333,
+              "end": 948333,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1834716,
+              "end": 2234716,
+              "category": "a"
+            }
+          ],
+          "bestAlignmentDisorder": 1.5185332298278809
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 13.419993765403815,
+            "end": 17.419993765403817,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 3.5352291091501664,
+            "end": 7.535229109150166,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 41.057931528299996,
+            "end": 45.057931528299996,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 49.97685625508623,
+            "end": 53.97685625508623,
+            "category": "b"
+          }
+        ],
+        "bestAlignmentDisorder": 2.0,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 1341999,
+              "end": 1741999,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 353523,
+              "end": 753523,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 4105793,
+              "end": 4505793,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 4997686,
+              "end": 5397686,
+              "category": "b"
+            }
+          ],
+          "bestAlignmentDisorder": 2.0
+        }
+      }
+    ]
+  },
+  "tier3": {
+    "expectedDisorder": 1.6350783109664917,
+    "gamma": 0.5667893886566162,
+    "nSamples": 30
+  }
+}

--- a/dkpro-statistics-agreement/src/test/resources/pygamma/fixture_03_identical_perfect.json
+++ b/dkpro-statistics-agreement/src/test/resources/pygamma/fixture_03_identical_perfect.json
@@ -1,0 +1,978 @@
+{
+  "metadata": {
+    "pygammaVersion": "0.5.9",
+    "pygammaRepo": "https://github.com/bootphon/pygamma-agreement",
+    "pygammaCommit": "44587ef",
+    "solver": "GLPK_MI",
+    "seed": 3,
+    "description": "2 annotators with identical annotations: observed disorder is 0, so gamma is 1."
+  },
+  "params": {
+    "alpha": 1.0,
+    "beta": 1.0,
+    "deltaEmpty": 1.0
+  },
+  "continuum": [
+    {
+      "annotator": "Ann1",
+      "start": 1,
+      "end": 5,
+      "category": "a"
+    },
+    {
+      "annotator": "Ann1",
+      "start": 10,
+      "end": 15,
+      "category": "b"
+    },
+    {
+      "annotator": "Ann1",
+      "start": 20,
+      "end": 25,
+      "category": "c"
+    },
+    {
+      "annotator": "Ann2",
+      "start": 1,
+      "end": 5,
+      "category": "a"
+    },
+    {
+      "annotator": "Ann2",
+      "start": 10,
+      "end": 15,
+      "category": "b"
+    },
+    {
+      "annotator": "Ann2",
+      "start": 20,
+      "end": 25,
+      "category": "c"
+    }
+  ],
+  "tier1": {
+    "pairDissimilarities": [
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 0,
+        "annotatorB": "Ann2",
+        "unitIndexB": 0,
+        "positional": 0.0,
+        "categorical": 0.0,
+        "combined": 0.0
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 0,
+        "annotatorB": "Ann2",
+        "unitIndexB": 1,
+        "positional": 4.456789970397949,
+        "categorical": 1.0,
+        "combined": 5.456789970397949
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 0,
+        "annotatorB": "Ann2",
+        "unitIndexB": 2,
+        "positional": 18.77777862548828,
+        "categorical": 1.0,
+        "combined": 19.77777862548828
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 1,
+        "annotatorB": "Ann2",
+        "unitIndexB": 0,
+        "positional": 4.456789970397949,
+        "categorical": 1.0,
+        "combined": 5.456789970397949
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 1,
+        "annotatorB": "Ann2",
+        "unitIndexB": 1,
+        "positional": 0.0,
+        "categorical": 0.0,
+        "combined": 0.0
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 1,
+        "annotatorB": "Ann2",
+        "unitIndexB": 2,
+        "positional": 4.0,
+        "categorical": 1.0,
+        "combined": 5.0
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 2,
+        "annotatorB": "Ann2",
+        "unitIndexB": 0,
+        "positional": 18.77777862548828,
+        "categorical": 1.0,
+        "combined": 19.77777862548828
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 2,
+        "annotatorB": "Ann2",
+        "unitIndexB": 1,
+        "positional": 4.0,
+        "categorical": 1.0,
+        "combined": 5.0
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 2,
+        "annotatorB": "Ann2",
+        "unitIndexB": 2,
+        "positional": 0.0,
+        "categorical": 0.0,
+        "combined": 0.0
+      }
+    ],
+    "bestAlignmentDisorder": 0.0
+  },
+  "tier2": {
+    "sampledContinua": [
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 4.088571379009708,
+            "end": 8.800727388370408,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 7.90626079965274,
+            "end": 12.356061530884725,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 15.373431096644222,
+            "end": 19.420735978867725,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 2.390353868723219,
+            "end": 7.088274058090929,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 9.049589328098534,
+            "end": 12.987239596898611,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 14.915082057040298,
+            "end": 20.439225339408758,
+            "category": "a"
+          }
+        ],
+        "bestAlignmentDisorder": 1.0666457414627075,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 408857,
+              "end": 880073,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 790626,
+              "end": 1235606,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1537343,
+              "end": 1942074,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 239035,
+              "end": 708827,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 904959,
+              "end": 1298724,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1491508,
+              "end": 2043923,
+              "category": "a"
+            }
+          ],
+          "bestAlignmentDisorder": 1.066645860671997
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 3.6557114199892853,
+            "end": 7.839761143375936,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 9.43789296368868,
+            "end": 14.419482558808506,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 18.181704213649738,
+            "end": 22.48593794902744,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": -1.2437105156957258,
+            "end": 3.8217422927770106,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 5.223211383826743,
+            "end": 8.74951130648747,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 11.09402888109263,
+            "end": 14.90596085031462,
+            "category": "c"
+          }
+        ],
+        "bestAlignmentDisorder": 1.0541986227035522,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 365571,
+              "end": 783976,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 943789,
+              "end": 1441948,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1818170,
+              "end": 2248594,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": -124371,
+              "end": 382174,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 522321,
+              "end": 874951,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1109403,
+              "end": 1490596,
+              "category": "c"
+            }
+          ],
+          "bestAlignmentDisorder": 1.0541988611221313
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 4.543902687797263,
+            "end": 9.04262170783508,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 8.408901317939954,
+            "end": 13.107311751703662,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 13.146058938697605,
+            "end": 16.752886729825107,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 4.964305141532095,
+            "end": 10.142713210405855,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 16.508385863992643,
+            "end": 20.647880532429273,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 19.84510503014433,
+            "end": 24.870535828228427,
+            "category": "b"
+          }
+        ],
+        "bestAlignmentDisorder": 1.6341396570205688,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 454390,
+              "end": 904262,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 840890,
+              "end": 1310731,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1314606,
+              "end": 1675289,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 496431,
+              "end": 1014271,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1650839,
+              "end": 2064788,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1984511,
+              "end": 2487054,
+              "category": "b"
+            }
+          ],
+          "bestAlignmentDisorder": 1.6341396570205688
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 6.032447931386654,
+            "end": 10.606052425827611,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 17.593741634557944,
+            "end": 22.055103957829832,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 24.382095400387982,
+            "end": 29.120861362772445,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 3.402808703227364,
+            "end": 8.21027839406988,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 9.13258606237961,
+            "end": 14.223204938136817,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 18.452072551159024,
+            "end": 23.472888903348476,
+            "category": "b"
+          }
+        ],
+        "bestAlignmentDisorder": 1.1148637533187866,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 603245,
+              "end": 1060605,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1759374,
+              "end": 2205510,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 2438210,
+              "end": 2912086,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 340281,
+              "end": 821028,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 913259,
+              "end": 1422320,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1845207,
+              "end": 2347289,
+              "category": "b"
+            }
+          ],
+          "bestAlignmentDisorder": 1.1148637533187866
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 4.607904209539017,
+            "end": 9.577760954285296,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 13.260273374819867,
+            "end": 18.31258956768984,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 16.959078557174138,
+            "end": 21.915223939122278,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 1.2532317054886548,
+            "end": 5.96359301989653,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 2.789399820078521,
+            "end": 6.997936480344632,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 10.763167288684233,
+            "end": 15.808908793141896,
+            "category": "a"
+          }
+        ],
+        "bestAlignmentDisorder": 0.9211697578430176,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 460790,
+              "end": 957776,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1326027,
+              "end": 1831259,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1695908,
+              "end": 2191522,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 125323,
+              "end": 596359,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 278940,
+              "end": 699794,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1076317,
+              "end": 1580891,
+              "category": "a"
+            }
+          ],
+          "bestAlignmentDisorder": 0.9211693406105042
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 2.9057204055347756,
+            "end": 7.892504494299985,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 9.182026351397129,
+            "end": 13.012646917457374,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 15.796859482505283,
+            "end": 20.425935910419152,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 3.251170262366762,
+            "end": 8.183632131748858,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 10.17696404218242,
+            "end": 14.49925714645375,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 16.996392679475708,
+            "end": 22.011918179743887,
+            "category": "a"
+          }
+        ],
+        "bestAlignmentDisorder": 0.7267259955406189,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 290572,
+              "end": 789250,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 918203,
+              "end": 1301265,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1579686,
+              "end": 2042594,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 325117,
+              "end": 818363,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1017696,
+              "end": 1449926,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1699639,
+              "end": 2201192,
+              "category": "a"
+            }
+          ],
+          "bestAlignmentDisorder": 0.7267255187034607
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 4.712853932002235,
+            "end": 9.054270016215103,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 13.25096155339956,
+            "end": 18.1501618059617,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 22.899329757350138,
+            "end": 27.24628390091759,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 5.301981724790942,
+            "end": 9.868494182872944,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 13.500447368702524,
+            "end": 18.30242370963233,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 18.835051353653444,
+            "end": 23.247066700579545,
+            "category": "a"
+          }
+        ],
+        "bestAlignmentDisorder": 0.9580119252204895,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 471285,
+              "end": 905427,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1325096,
+              "end": 1815016,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 2289933,
+              "end": 2724628,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 530198,
+              "end": 986849,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1350045,
+              "end": 1830242,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1883505,
+              "end": 2324707,
+              "category": "a"
+            }
+          ],
+          "bestAlignmentDisorder": 0.9580113887786865
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 7.279373780824154,
+            "end": 12.330147705842966,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 14.346424076341336,
+            "end": 18.971519955001533,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 21.840039799507267,
+            "end": 26.29115166393647,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 6.05180531729719,
+            "end": 9.608359010915285,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 13.02854968616895,
+            "end": 18.280519992584374,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 19.76063688667573,
+            "end": 25.006109941707006,
+            "category": "c"
+          }
+        ],
+        "bestAlignmentDisorder": 0.7907624244689941,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 727937,
+              "end": 1233015,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1434642,
+              "end": 1897152,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 2184004,
+              "end": 2629115,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 605181,
+              "end": 960836,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1302855,
+              "end": 1828052,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1976064,
+              "end": 2500611,
+              "category": "c"
+            }
+          ],
+          "bestAlignmentDisorder": 0.7907619476318359
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 4.209050384131034,
+            "end": 8.469220931739184,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 13.933919718863358,
+            "end": 19.21049191591945,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 22.37678786568494,
+            "end": 26.701481910158577,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 1.5363345240516209,
+            "end": 6.159097414830642,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 7.577576848315365,
+            "end": 12.278536086291354,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 15.204827348462903,
+            "end": 18.518894661000946,
+            "category": "b"
+          }
+        ],
+        "bestAlignmentDisorder": 1.4556158781051636,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 420905,
+              "end": 846922,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1393392,
+              "end": 1921049,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 2237679,
+              "end": 2670148,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 153633,
+              "end": 615910,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 757758,
+              "end": 1227854,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1520483,
+              "end": 1851889,
+              "category": "b"
+            }
+          ],
+          "bestAlignmentDisorder": 1.4556158781051636
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 6.194697936024227,
+            "end": 10.35668575849708,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 14.303045988166893,
+            "end": 18.75756004211127,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 22.740002069983127,
+            "end": 27.345687371839055,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 3.056835689593838,
+            "end": 7.49487537846465,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 12.888659520816784,
+            "end": 17.853133248706932,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 19.095039698057526,
+            "end": 24.500487565815085,
+            "category": "a"
+          }
+        ],
+        "bestAlignmentDisorder": 0.655862033367157,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 619470,
+              "end": 1035669,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1430305,
+              "end": 1875756,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 2274000,
+              "end": 2734569,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 305684,
+              "end": 749488,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1288866,
+              "end": 1785313,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1909504,
+              "end": 2450049,
+              "category": "a"
+            }
+          ],
+          "bestAlignmentDisorder": 0.6558616757392883
+        }
+      }
+    ]
+  },
+  "tier3": {
+    "expectedDisorder": 1.0543665885925293,
+    "gamma": 1.0,
+    "nSamples": 30
+  }
+}

--- a/dkpro-statistics-agreement/src/test/resources/pygamma/fixture_04_three_annotators.json
+++ b/dkpro-statistics-agreement/src/test/resources/pygamma/fixture_04_three_annotators.json
@@ -1,0 +1,1005 @@
+{
+  "metadata": {
+    "pygammaVersion": "0.5.9",
+    "pygammaRepo": "https://github.com/bootphon/pygamma-agreement",
+    "pygammaCommit": "44587ef",
+    "solver": "GLPK_MI",
+    "seed": 4,
+    "description": "3 annotators, 2 units each, with positional and one categorical disagreement."
+  },
+  "params": {
+    "alpha": 1.0,
+    "beta": 1.0,
+    "deltaEmpty": 1.0
+  },
+  "continuum": [
+    {
+      "annotator": "Ann1",
+      "start": 1,
+      "end": 5,
+      "category": "a"
+    },
+    {
+      "annotator": "Ann1",
+      "start": 10,
+      "end": 14,
+      "category": "b"
+    },
+    {
+      "annotator": "Ann2",
+      "start": 2,
+      "end": 6,
+      "category": "a"
+    },
+    {
+      "annotator": "Ann2",
+      "start": 11,
+      "end": 15,
+      "category": "b"
+    },
+    {
+      "annotator": "Ann3",
+      "start": 1,
+      "end": 4,
+      "category": "a"
+    },
+    {
+      "annotator": "Ann3",
+      "start": 9,
+      "end": 14,
+      "category": "c"
+    }
+  ],
+  "tier1": {
+    "pairDissimilarities": [
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 0,
+        "annotatorB": "Ann2",
+        "unitIndexB": 0,
+        "positional": 0.0625,
+        "categorical": 0.0,
+        "combined": 0.0625
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 0,
+        "annotatorB": "Ann2",
+        "unitIndexB": 1,
+        "positional": 6.25,
+        "categorical": 1.0,
+        "combined": 7.25
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 1,
+        "annotatorB": "Ann2",
+        "unitIndexB": 0,
+        "positional": 4.0,
+        "categorical": 1.0,
+        "combined": 5.0
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 1,
+        "annotatorB": "Ann2",
+        "unitIndexB": 1,
+        "positional": 0.0625,
+        "categorical": 0.0,
+        "combined": 0.0625
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 0,
+        "annotatorB": "Ann3",
+        "unitIndexB": 0,
+        "positional": 0.020408162847161293,
+        "categorical": 0.0,
+        "combined": 0.020408162847161293
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 0,
+        "annotatorB": "Ann3",
+        "unitIndexB": 1,
+        "positional": 3.567901134490967,
+        "categorical": 1.0,
+        "combined": 4.567901134490967
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 1,
+        "annotatorB": "Ann3",
+        "unitIndexB": 0,
+        "positional": 7.36734676361084,
+        "categorical": 1.0,
+        "combined": 8.36734676361084
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 1,
+        "annotatorB": "Ann3",
+        "unitIndexB": 1,
+        "positional": 0.012345679104328156,
+        "categorical": 1.0,
+        "combined": 1.0123456716537476
+      },
+      {
+        "annotatorA": "Ann2",
+        "unitIndexA": 0,
+        "annotatorB": "Ann3",
+        "unitIndexB": 0,
+        "positional": 0.18367347121238708,
+        "categorical": 0.0,
+        "combined": 0.18367347121238708
+      },
+      {
+        "annotatorA": "Ann2",
+        "unitIndexA": 0,
+        "annotatorB": "Ann3",
+        "unitIndexB": 1,
+        "positional": 2.777777671813965,
+        "categorical": 1.0,
+        "combined": 3.777777671813965
+      },
+      {
+        "annotatorA": "Ann2",
+        "unitIndexA": 1,
+        "annotatorB": "Ann3",
+        "unitIndexB": 0,
+        "positional": 9.0,
+        "categorical": 1.0,
+        "combined": 10.0
+      },
+      {
+        "annotatorA": "Ann2",
+        "unitIndexA": 1,
+        "annotatorB": "Ann3",
+        "unitIndexB": 1,
+        "positional": 0.1111111119389534,
+        "categorical": 1.0,
+        "combined": 1.1111111640930176
+      }
+    ],
+    "bestAlignmentDisorder": 0.40875643491744995
+  },
+  "tier2": {
+    "sampledContinua": [
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 3.739378792537379,
+            "end": 7.164390503074478,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 11.300820699564976,
+            "end": 16.138917134227825,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 3.3955264392011246,
+            "end": 6.733030496281247,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 8.453036351042616,
+            "end": 12.383369995930018,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann3",
+            "start": 2.533878572186274,
+            "end": 6.779294234723135,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann3",
+            "start": 10.1748270562878,
+            "end": 14.272698176941343,
+            "category": "a"
+          }
+        ],
+        "bestAlignmentDisorder": 0.8253426551818848,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 373938,
+              "end": 716439,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1130082,
+              "end": 1613892,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 339553,
+              "end": 673303,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 845304,
+              "end": 1238337,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann3",
+              "start": 253388,
+              "end": 677929,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann3",
+              "start": 1017483,
+              "end": 1427270,
+              "category": "a"
+            }
+          ],
+          "bestAlignmentDisorder": 0.8253426551818848
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 1.4699326906561878,
+            "end": 6.363081622694205,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 9.151188796103702,
+            "end": 13.570419821472388,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 0.23547566319096905,
+            "end": 5.519133282930137,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 9.041876277995224,
+            "end": 12.38351464912028,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann3",
+            "start": 1.3790215600695561,
+            "end": 5.692205968998483,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann3",
+            "start": 12.47640755762505,
+            "end": 16.491958863470707,
+            "category": "a"
+          }
+        ],
+        "bestAlignmentDisorder": 0.9491496086120605,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 146993,
+              "end": 636308,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 915119,
+              "end": 1357042,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 23548,
+              "end": 551913,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 904188,
+              "end": 1238351,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann3",
+              "start": 137902,
+              "end": 569221,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann3",
+              "start": 1247641,
+              "end": 1649196,
+              "category": "a"
+            }
+          ],
+          "bestAlignmentDisorder": 0.9491503238677979
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 4.590062557341935,
+            "end": 8.430596476405938,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 12.778038819838205,
+            "end": 16.77230368821116,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 2.4462907887708916,
+            "end": 6.909375711063197,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 11.378319692913173,
+            "end": 15.27670771071711,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann3",
+            "start": -1.0602198895988244,
+            "end": 2.96145816184545,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann3",
+            "start": 5.749410239980914,
+            "end": 9.854337303865965,
+            "category": "a"
+          }
+        ],
+        "bestAlignmentDisorder": 1.3278087377548218,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 459006,
+              "end": 843060,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1277804,
+              "end": 1677230,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 244629,
+              "end": 690938,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1137832,
+              "end": 1527671,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann3",
+              "start": -106022,
+              "end": 296146,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann3",
+              "start": 574941,
+              "end": 985434,
+              "category": "a"
+            }
+          ],
+          "bestAlignmentDisorder": 1.3278082609176636
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 3.7595290019513823,
+            "end": 7.932991317049364,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 9.313156425614,
+            "end": 13.402607200668317,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 0.7422722880030035,
+            "end": 5.476557109076492,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 6.862921716281457,
+            "end": 11.052139468076817,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann3",
+            "start": 5.101319273110454,
+            "end": 9.241419180980802,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann3",
+            "start": 12.049200072317866,
+            "end": 16.846282311680323,
+            "category": "c"
+          }
+        ],
+        "bestAlignmentDisorder": 1.271691083908081,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 375953,
+              "end": 793299,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 931316,
+              "end": 1340261,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 74227,
+              "end": 547656,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 686292,
+              "end": 1105214,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann3",
+              "start": 510132,
+              "end": 924142,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann3",
+              "start": 1204920,
+              "end": 1684628,
+              "category": "c"
+            }
+          ],
+          "bestAlignmentDisorder": 1.2716907262802124
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 3.596507910967723,
+            "end": 8.136128376465944,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 10.14077175158569,
+            "end": 14.07126794584369,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 0.5095262599117557,
+            "end": 5.67716236951926,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 5.057392402169078,
+            "end": 8.042499752635102,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann3",
+            "start": 3.101083196997594,
+            "end": 7.221930395913434,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann3",
+            "start": 9.168459597557725,
+            "end": 12.887912221883964,
+            "category": "a"
+          }
+        ],
+        "bestAlignmentDisorder": 1.2597535848617554,
+        "scaled": {
+          "scale": 1000000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 3596508,
+              "end": 8136128,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 10140772,
+              "end": 14071268,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 509526,
+              "end": 5677162,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 5057392,
+              "end": 8042500,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann3",
+              "start": 3101083,
+              "end": 7221930,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann3",
+              "start": 9168460,
+              "end": 12887912,
+              "category": "a"
+            }
+          ],
+          "bestAlignmentDisorder": 1.2597535848617554
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 0.777965816298324,
+            "end": 4.940123112256834,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 6.809143079500316,
+            "end": 11.576063633163681,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 2.289483360327158,
+            "end": 6.306842598062786,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 8.331829967195464,
+            "end": 12.597575986202077,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann3",
+            "start": -0.7364414741716203,
+            "end": 3.013054107981932,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann3",
+            "start": 6.25554904147832,
+            "end": 9.803027949491353,
+            "category": "a"
+          }
+        ],
+        "bestAlignmentDisorder": 1.2535645961761475,
+        "scaled": {
+          "scale": 1000000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 777966,
+              "end": 4940123,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 6809143,
+              "end": 11576064,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 2289483,
+              "end": 6306843,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 8331830,
+              "end": 12597576,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann3",
+              "start": -736441,
+              "end": 3013054,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann3",
+              "start": 6255549,
+              "end": 9803028,
+              "category": "a"
+            }
+          ],
+          "bestAlignmentDisorder": 1.2535645961761475
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 1.789473770214502,
+            "end": 6.143696998211962,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 8.427080695208012,
+            "end": 11.674329691089849,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 4.187025270027059,
+            "end": 8.485261112873111,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 12.189864896123215,
+            "end": 16.51023289253869,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann3",
+            "start": -1.316802810461918,
+            "end": 3.2841647606083786,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann3",
+            "start": 5.160559706981443,
+            "end": 9.4262611924109,
+            "category": "c"
+          }
+        ],
+        "bestAlignmentDisorder": 1.6669913530349731,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 178947,
+              "end": 614370,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 842708,
+              "end": 1167433,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 418703,
+              "end": 848526,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1218986,
+              "end": 1651023,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann3",
+              "start": -131680,
+              "end": 328416,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann3",
+              "start": 516056,
+              "end": 942626,
+              "category": "c"
+            }
+          ],
+          "bestAlignmentDisorder": 1.6669912338256836
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 5.02788628887424,
+            "end": 9.13229045098263,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 12.719436508794818,
+            "end": 16.79322870860025,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 0.40736681539114594,
+            "end": 3.914915164204388,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 4.364396853874865,
+            "end": 8.179527846730224,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann3",
+            "start": 2.5502969112719565,
+            "end": 6.925453536738624,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann3",
+            "start": 10.961309381688356,
+            "end": 15.057319223731554,
+            "category": "b"
+          }
+        ],
+        "bestAlignmentDisorder": 1.445013165473938,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 502789,
+              "end": 913229,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1271944,
+              "end": 1679323,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 40737,
+              "end": 391492,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 436440,
+              "end": 817953,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann3",
+              "start": 255030,
+              "end": 692545,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann3",
+              "start": 1096131,
+              "end": 1505732,
+              "category": "b"
+            }
+          ],
+          "bestAlignmentDisorder": 1.4450135231018066
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 4.776936833709963,
+            "end": 9.661316700632629,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 11.158489748600324,
+            "end": 14.876849533241566,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 1.8917184932056135,
+            "end": 6.4085072463469155,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 7.884631613264295,
+            "end": 11.67214113893518,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann3",
+            "start": -0.39185243973231854,
+            "end": 3.6400043453936726,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann3",
+            "start": 3.4011915116155644,
+            "end": 7.668192912092408,
+            "category": "a"
+          }
+        ],
+        "bestAlignmentDisorder": 1.0676971673965454,
+        "scaled": {
+          "scale": 1000000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 4776937,
+              "end": 9661317,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 11158490,
+              "end": 14876850,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1891718,
+              "end": 6408507,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 7884632,
+              "end": 11672141,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann3",
+              "start": -391852,
+              "end": 3640004,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann3",
+              "start": 3401192,
+              "end": 7668193,
+              "category": "a"
+            }
+          ],
+          "bestAlignmentDisorder": 1.067697286605835
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 7.23244192852311,
+            "end": 11.854614399169158,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 14.61119068868979,
+            "end": 19.075443789108473,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 2.219612372635849,
+            "end": 6.074006073799142,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 6.159527455209364,
+            "end": 9.209038021006155,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann3",
+            "start": 1.7638397224518332,
+            "end": 5.572475500544021,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann3",
+            "start": 7.3274324216907685,
+            "end": 11.258632772722967,
+            "category": "c"
+          }
+        ],
+        "bestAlignmentDisorder": 1.4115850925445557,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 723244,
+              "end": 1185461,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1461119,
+              "end": 1907544,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 221961,
+              "end": 607401,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 615953,
+              "end": 920904,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann3",
+              "start": 176384,
+              "end": 557248,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann3",
+              "start": 732743,
+              "end": 1125863,
+              "category": "c"
+            }
+          ],
+          "bestAlignmentDisorder": 1.4115846157073975
+        }
+      }
+    ]
+  },
+  "tier3": {
+    "expectedDisorder": 1.1979972124099731,
+    "gamma": 0.6588001847267151,
+    "nSamples": 30
+  }
+}

--- a/dkpro-statistics-agreement/src/test/resources/pygamma/fixture_05_larger_two_annotators.json
+++ b/dkpro-statistics-agreement/src/test/resources/pygamma/fixture_05_larger_two_annotators.json
@@ -1,0 +1,6477 @@
+{
+  "metadata": {
+    "pygammaVersion": "0.5.9",
+    "pygammaRepo": "https://github.com/bootphon/pygamma-agreement",
+    "pygammaCommit": "44587ef",
+    "solver": "GLPK_MI",
+    "seed": 5,
+    "description": "2 annotators, 16 units each, regular offsets, cycling categories; a larger continuum for the ILP."
+  },
+  "params": {
+    "alpha": 1.0,
+    "beta": 1.0,
+    "deltaEmpty": 1.0
+  },
+  "continuum": [
+    {
+      "annotator": "Ann1",
+      "start": 1,
+      "end": 6,
+      "category": "a"
+    },
+    {
+      "annotator": "Ann1",
+      "start": 11,
+      "end": 16,
+      "category": "b"
+    },
+    {
+      "annotator": "Ann1",
+      "start": 21,
+      "end": 26,
+      "category": "c"
+    },
+    {
+      "annotator": "Ann1",
+      "start": 31,
+      "end": 36,
+      "category": "a"
+    },
+    {
+      "annotator": "Ann1",
+      "start": 41,
+      "end": 46,
+      "category": "b"
+    },
+    {
+      "annotator": "Ann1",
+      "start": 51,
+      "end": 56,
+      "category": "c"
+    },
+    {
+      "annotator": "Ann1",
+      "start": 61,
+      "end": 66,
+      "category": "a"
+    },
+    {
+      "annotator": "Ann1",
+      "start": 71,
+      "end": 76,
+      "category": "b"
+    },
+    {
+      "annotator": "Ann1",
+      "start": 81,
+      "end": 86,
+      "category": "c"
+    },
+    {
+      "annotator": "Ann1",
+      "start": 91,
+      "end": 96,
+      "category": "a"
+    },
+    {
+      "annotator": "Ann1",
+      "start": 101,
+      "end": 106,
+      "category": "b"
+    },
+    {
+      "annotator": "Ann1",
+      "start": 111,
+      "end": 116,
+      "category": "c"
+    },
+    {
+      "annotator": "Ann1",
+      "start": 121,
+      "end": 126,
+      "category": "a"
+    },
+    {
+      "annotator": "Ann1",
+      "start": 131,
+      "end": 136,
+      "category": "b"
+    },
+    {
+      "annotator": "Ann1",
+      "start": 141,
+      "end": 146,
+      "category": "c"
+    },
+    {
+      "annotator": "Ann1",
+      "start": 151,
+      "end": 156,
+      "category": "a"
+    },
+    {
+      "annotator": "Ann2",
+      "start": 2,
+      "end": 8,
+      "category": "b"
+    },
+    {
+      "annotator": "Ann2",
+      "start": 12,
+      "end": 18,
+      "category": "c"
+    },
+    {
+      "annotator": "Ann2",
+      "start": 22,
+      "end": 28,
+      "category": "a"
+    },
+    {
+      "annotator": "Ann2",
+      "start": 32,
+      "end": 38,
+      "category": "b"
+    },
+    {
+      "annotator": "Ann2",
+      "start": 42,
+      "end": 48,
+      "category": "c"
+    },
+    {
+      "annotator": "Ann2",
+      "start": 52,
+      "end": 58,
+      "category": "a"
+    },
+    {
+      "annotator": "Ann2",
+      "start": 62,
+      "end": 68,
+      "category": "b"
+    },
+    {
+      "annotator": "Ann2",
+      "start": 72,
+      "end": 78,
+      "category": "c"
+    },
+    {
+      "annotator": "Ann2",
+      "start": 82,
+      "end": 88,
+      "category": "a"
+    },
+    {
+      "annotator": "Ann2",
+      "start": 92,
+      "end": 98,
+      "category": "b"
+    },
+    {
+      "annotator": "Ann2",
+      "start": 102,
+      "end": 108,
+      "category": "c"
+    },
+    {
+      "annotator": "Ann2",
+      "start": 112,
+      "end": 118,
+      "category": "a"
+    },
+    {
+      "annotator": "Ann2",
+      "start": 122,
+      "end": 128,
+      "category": "b"
+    },
+    {
+      "annotator": "Ann2",
+      "start": 132,
+      "end": 138,
+      "category": "c"
+    },
+    {
+      "annotator": "Ann2",
+      "start": 142,
+      "end": 148,
+      "category": "a"
+    },
+    {
+      "annotator": "Ann2",
+      "start": 152,
+      "end": 158,
+      "category": "b"
+    }
+  ],
+  "tier1": {
+    "pairDissimilarities": [
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 0,
+        "annotatorB": "Ann2",
+        "unitIndexB": 0,
+        "positional": 0.07438016682863235,
+        "categorical": 1.0,
+        "combined": 1.0743801593780518
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 0,
+        "annotatorB": "Ann2",
+        "unitIndexB": 1,
+        "positional": 4.371901035308838,
+        "categorical": 1.0,
+        "combined": 5.371901035308838
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 0,
+        "annotatorB": "Ann2",
+        "unitIndexB": 2,
+        "positional": 15.280991554260254,
+        "categorical": 0.0,
+        "combined": 15.280991554260254
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 0,
+        "annotatorB": "Ann2",
+        "unitIndexB": 3,
+        "positional": 32.80165100097656,
+        "categorical": 1.0,
+        "combined": 33.80165100097656
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 0,
+        "annotatorB": "Ann2",
+        "unitIndexB": 4,
+        "positional": 56.93388366699219,
+        "categorical": 1.0,
+        "combined": 57.93388366699219
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 0,
+        "annotatorB": "Ann2",
+        "unitIndexB": 5,
+        "positional": 87.67768859863281,
+        "categorical": 0.0,
+        "combined": 87.67768859863281
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 0,
+        "annotatorB": "Ann2",
+        "unitIndexB": 6,
+        "positional": 125.0330581665039,
+        "categorical": 1.0,
+        "combined": 126.0330581665039
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 0,
+        "annotatorB": "Ann2",
+        "unitIndexB": 7,
+        "positional": 169.0,
+        "categorical": 1.0,
+        "combined": 170.0
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 0,
+        "annotatorB": "Ann2",
+        "unitIndexB": 8,
+        "positional": 219.57850646972656,
+        "categorical": 0.0,
+        "combined": 219.57850646972656
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 0,
+        "annotatorB": "Ann2",
+        "unitIndexB": 9,
+        "positional": 276.7685852050781,
+        "categorical": 1.0,
+        "combined": 277.7685852050781
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 0,
+        "annotatorB": "Ann2",
+        "unitIndexB": 10,
+        "positional": 340.57025146484375,
+        "categorical": 1.0,
+        "combined": 341.57025146484375
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 0,
+        "annotatorB": "Ann2",
+        "unitIndexB": 11,
+        "positional": 410.98345947265625,
+        "categorical": 0.0,
+        "combined": 410.98345947265625
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 0,
+        "annotatorB": "Ann2",
+        "unitIndexB": 12,
+        "positional": 488.0082702636719,
+        "categorical": 1.0,
+        "combined": 489.0082702636719
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 0,
+        "annotatorB": "Ann2",
+        "unitIndexB": 13,
+        "positional": 571.6446533203125,
+        "categorical": 1.0,
+        "combined": 572.6446533203125
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 0,
+        "annotatorB": "Ann2",
+        "unitIndexB": 14,
+        "positional": 661.892578125,
+        "categorical": 0.0,
+        "combined": 661.892578125
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 0,
+        "annotatorB": "Ann2",
+        "unitIndexB": 15,
+        "positional": 758.7520751953125,
+        "categorical": 1.0,
+        "combined": 759.7520751953125
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 1,
+        "annotatorB": "Ann2",
+        "unitIndexB": 0,
+        "positional": 2.388429641723633,
+        "categorical": 0.0,
+        "combined": 2.388429641723633
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 1,
+        "annotatorB": "Ann2",
+        "unitIndexB": 1,
+        "positional": 0.07438016682863235,
+        "categorical": 1.0,
+        "combined": 1.0743801593780518
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 1,
+        "annotatorB": "Ann2",
+        "unitIndexB": 2,
+        "positional": 4.371901035308838,
+        "categorical": 1.0,
+        "combined": 5.371901035308838
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 1,
+        "annotatorB": "Ann2",
+        "unitIndexB": 3,
+        "positional": 15.280991554260254,
+        "categorical": 0.0,
+        "combined": 15.280991554260254
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 1,
+        "annotatorB": "Ann2",
+        "unitIndexB": 4,
+        "positional": 32.80165100097656,
+        "categorical": 1.0,
+        "combined": 33.80165100097656
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 1,
+        "annotatorB": "Ann2",
+        "unitIndexB": 5,
+        "positional": 56.93388366699219,
+        "categorical": 1.0,
+        "combined": 57.93388366699219
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 1,
+        "annotatorB": "Ann2",
+        "unitIndexB": 6,
+        "positional": 87.67768859863281,
+        "categorical": 0.0,
+        "combined": 87.67768859863281
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 1,
+        "annotatorB": "Ann2",
+        "unitIndexB": 7,
+        "positional": 125.0330581665039,
+        "categorical": 1.0,
+        "combined": 126.0330581665039
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 1,
+        "annotatorB": "Ann2",
+        "unitIndexB": 8,
+        "positional": 169.0,
+        "categorical": 1.0,
+        "combined": 170.0
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 1,
+        "annotatorB": "Ann2",
+        "unitIndexB": 9,
+        "positional": 219.57850646972656,
+        "categorical": 0.0,
+        "combined": 219.57850646972656
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 1,
+        "annotatorB": "Ann2",
+        "unitIndexB": 10,
+        "positional": 276.7685852050781,
+        "categorical": 1.0,
+        "combined": 277.7685852050781
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 1,
+        "annotatorB": "Ann2",
+        "unitIndexB": 11,
+        "positional": 340.57025146484375,
+        "categorical": 1.0,
+        "combined": 341.57025146484375
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 1,
+        "annotatorB": "Ann2",
+        "unitIndexB": 12,
+        "positional": 410.98345947265625,
+        "categorical": 0.0,
+        "combined": 410.98345947265625
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 1,
+        "annotatorB": "Ann2",
+        "unitIndexB": 13,
+        "positional": 488.0082702636719,
+        "categorical": 1.0,
+        "combined": 489.0082702636719
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 1,
+        "annotatorB": "Ann2",
+        "unitIndexB": 14,
+        "positional": 571.6446533203125,
+        "categorical": 1.0,
+        "combined": 572.6446533203125
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 1,
+        "annotatorB": "Ann2",
+        "unitIndexB": 15,
+        "positional": 661.892578125,
+        "categorical": 0.0,
+        "combined": 661.892578125
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 2,
+        "annotatorB": "Ann2",
+        "unitIndexB": 0,
+        "positional": 11.31404972076416,
+        "categorical": 1.0,
+        "combined": 12.31404972076416
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 2,
+        "annotatorB": "Ann2",
+        "unitIndexB": 1,
+        "positional": 2.388429641723633,
+        "categorical": 0.0,
+        "combined": 2.388429641723633
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 2,
+        "annotatorB": "Ann2",
+        "unitIndexB": 2,
+        "positional": 0.07438016682863235,
+        "categorical": 1.0,
+        "combined": 1.0743801593780518
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 2,
+        "annotatorB": "Ann2",
+        "unitIndexB": 3,
+        "positional": 4.371901035308838,
+        "categorical": 1.0,
+        "combined": 5.371901035308838
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 2,
+        "annotatorB": "Ann2",
+        "unitIndexB": 4,
+        "positional": 15.280991554260254,
+        "categorical": 0.0,
+        "combined": 15.280991554260254
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 2,
+        "annotatorB": "Ann2",
+        "unitIndexB": 5,
+        "positional": 32.80165100097656,
+        "categorical": 1.0,
+        "combined": 33.80165100097656
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 2,
+        "annotatorB": "Ann2",
+        "unitIndexB": 6,
+        "positional": 56.93388366699219,
+        "categorical": 1.0,
+        "combined": 57.93388366699219
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 2,
+        "annotatorB": "Ann2",
+        "unitIndexB": 7,
+        "positional": 87.67768859863281,
+        "categorical": 0.0,
+        "combined": 87.67768859863281
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 2,
+        "annotatorB": "Ann2",
+        "unitIndexB": 8,
+        "positional": 125.0330581665039,
+        "categorical": 1.0,
+        "combined": 126.0330581665039
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 2,
+        "annotatorB": "Ann2",
+        "unitIndexB": 9,
+        "positional": 169.0,
+        "categorical": 1.0,
+        "combined": 170.0
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 2,
+        "annotatorB": "Ann2",
+        "unitIndexB": 10,
+        "positional": 219.57850646972656,
+        "categorical": 0.0,
+        "combined": 219.57850646972656
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 2,
+        "annotatorB": "Ann2",
+        "unitIndexB": 11,
+        "positional": 276.7685852050781,
+        "categorical": 1.0,
+        "combined": 277.7685852050781
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 2,
+        "annotatorB": "Ann2",
+        "unitIndexB": 12,
+        "positional": 340.57025146484375,
+        "categorical": 1.0,
+        "combined": 341.57025146484375
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 2,
+        "annotatorB": "Ann2",
+        "unitIndexB": 13,
+        "positional": 410.98345947265625,
+        "categorical": 0.0,
+        "combined": 410.98345947265625
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 2,
+        "annotatorB": "Ann2",
+        "unitIndexB": 14,
+        "positional": 488.0082702636719,
+        "categorical": 1.0,
+        "combined": 489.0082702636719
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 2,
+        "annotatorB": "Ann2",
+        "unitIndexB": 15,
+        "positional": 571.6446533203125,
+        "categorical": 1.0,
+        "combined": 572.6446533203125
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 3,
+        "annotatorB": "Ann2",
+        "unitIndexB": 0,
+        "positional": 26.851240158081055,
+        "categorical": 1.0,
+        "combined": 27.851240158081055
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 3,
+        "annotatorB": "Ann2",
+        "unitIndexB": 1,
+        "positional": 11.31404972076416,
+        "categorical": 1.0,
+        "combined": 12.31404972076416
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 3,
+        "annotatorB": "Ann2",
+        "unitIndexB": 2,
+        "positional": 2.388429641723633,
+        "categorical": 0.0,
+        "combined": 2.388429641723633
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 3,
+        "annotatorB": "Ann2",
+        "unitIndexB": 3,
+        "positional": 0.07438016682863235,
+        "categorical": 1.0,
+        "combined": 1.0743801593780518
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 3,
+        "annotatorB": "Ann2",
+        "unitIndexB": 4,
+        "positional": 4.371901035308838,
+        "categorical": 1.0,
+        "combined": 5.371901035308838
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 3,
+        "annotatorB": "Ann2",
+        "unitIndexB": 5,
+        "positional": 15.280991554260254,
+        "categorical": 0.0,
+        "combined": 15.280991554260254
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 3,
+        "annotatorB": "Ann2",
+        "unitIndexB": 6,
+        "positional": 32.80165100097656,
+        "categorical": 1.0,
+        "combined": 33.80165100097656
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 3,
+        "annotatorB": "Ann2",
+        "unitIndexB": 7,
+        "positional": 56.93388366699219,
+        "categorical": 1.0,
+        "combined": 57.93388366699219
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 3,
+        "annotatorB": "Ann2",
+        "unitIndexB": 8,
+        "positional": 87.67768859863281,
+        "categorical": 0.0,
+        "combined": 87.67768859863281
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 3,
+        "annotatorB": "Ann2",
+        "unitIndexB": 9,
+        "positional": 125.0330581665039,
+        "categorical": 1.0,
+        "combined": 126.0330581665039
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 3,
+        "annotatorB": "Ann2",
+        "unitIndexB": 10,
+        "positional": 169.0,
+        "categorical": 1.0,
+        "combined": 170.0
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 3,
+        "annotatorB": "Ann2",
+        "unitIndexB": 11,
+        "positional": 219.57850646972656,
+        "categorical": 0.0,
+        "combined": 219.57850646972656
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 3,
+        "annotatorB": "Ann2",
+        "unitIndexB": 12,
+        "positional": 276.7685852050781,
+        "categorical": 1.0,
+        "combined": 277.7685852050781
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 3,
+        "annotatorB": "Ann2",
+        "unitIndexB": 13,
+        "positional": 340.57025146484375,
+        "categorical": 1.0,
+        "combined": 341.57025146484375
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 3,
+        "annotatorB": "Ann2",
+        "unitIndexB": 14,
+        "positional": 410.98345947265625,
+        "categorical": 0.0,
+        "combined": 410.98345947265625
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 3,
+        "annotatorB": "Ann2",
+        "unitIndexB": 15,
+        "positional": 488.0082702636719,
+        "categorical": 1.0,
+        "combined": 489.0082702636719
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 4,
+        "annotatorB": "Ann2",
+        "unitIndexB": 0,
+        "positional": 49.0,
+        "categorical": 0.0,
+        "combined": 49.0
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 4,
+        "annotatorB": "Ann2",
+        "unitIndexB": 1,
+        "positional": 26.851240158081055,
+        "categorical": 1.0,
+        "combined": 27.851240158081055
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 4,
+        "annotatorB": "Ann2",
+        "unitIndexB": 2,
+        "positional": 11.31404972076416,
+        "categorical": 1.0,
+        "combined": 12.31404972076416
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 4,
+        "annotatorB": "Ann2",
+        "unitIndexB": 3,
+        "positional": 2.388429641723633,
+        "categorical": 0.0,
+        "combined": 2.388429641723633
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 4,
+        "annotatorB": "Ann2",
+        "unitIndexB": 4,
+        "positional": 0.07438016682863235,
+        "categorical": 1.0,
+        "combined": 1.0743801593780518
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 4,
+        "annotatorB": "Ann2",
+        "unitIndexB": 5,
+        "positional": 4.371901035308838,
+        "categorical": 1.0,
+        "combined": 5.371901035308838
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 4,
+        "annotatorB": "Ann2",
+        "unitIndexB": 6,
+        "positional": 15.280991554260254,
+        "categorical": 0.0,
+        "combined": 15.280991554260254
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 4,
+        "annotatorB": "Ann2",
+        "unitIndexB": 7,
+        "positional": 32.80165100097656,
+        "categorical": 1.0,
+        "combined": 33.80165100097656
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 4,
+        "annotatorB": "Ann2",
+        "unitIndexB": 8,
+        "positional": 56.93388366699219,
+        "categorical": 1.0,
+        "combined": 57.93388366699219
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 4,
+        "annotatorB": "Ann2",
+        "unitIndexB": 9,
+        "positional": 87.67768859863281,
+        "categorical": 0.0,
+        "combined": 87.67768859863281
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 4,
+        "annotatorB": "Ann2",
+        "unitIndexB": 10,
+        "positional": 125.0330581665039,
+        "categorical": 1.0,
+        "combined": 126.0330581665039
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 4,
+        "annotatorB": "Ann2",
+        "unitIndexB": 11,
+        "positional": 169.0,
+        "categorical": 1.0,
+        "combined": 170.0
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 4,
+        "annotatorB": "Ann2",
+        "unitIndexB": 12,
+        "positional": 219.57850646972656,
+        "categorical": 0.0,
+        "combined": 219.57850646972656
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 4,
+        "annotatorB": "Ann2",
+        "unitIndexB": 13,
+        "positional": 276.7685852050781,
+        "categorical": 1.0,
+        "combined": 277.7685852050781
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 4,
+        "annotatorB": "Ann2",
+        "unitIndexB": 14,
+        "positional": 340.57025146484375,
+        "categorical": 1.0,
+        "combined": 341.57025146484375
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 4,
+        "annotatorB": "Ann2",
+        "unitIndexB": 15,
+        "positional": 410.98345947265625,
+        "categorical": 0.0,
+        "combined": 410.98345947265625
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 5,
+        "annotatorB": "Ann2",
+        "unitIndexB": 0,
+        "positional": 77.76033020019531,
+        "categorical": 1.0,
+        "combined": 78.76033020019531
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 5,
+        "annotatorB": "Ann2",
+        "unitIndexB": 1,
+        "positional": 49.0,
+        "categorical": 0.0,
+        "combined": 49.0
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 5,
+        "annotatorB": "Ann2",
+        "unitIndexB": 2,
+        "positional": 26.851240158081055,
+        "categorical": 1.0,
+        "combined": 27.851240158081055
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 5,
+        "annotatorB": "Ann2",
+        "unitIndexB": 3,
+        "positional": 11.31404972076416,
+        "categorical": 1.0,
+        "combined": 12.31404972076416
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 5,
+        "annotatorB": "Ann2",
+        "unitIndexB": 4,
+        "positional": 2.388429641723633,
+        "categorical": 0.0,
+        "combined": 2.388429641723633
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 5,
+        "annotatorB": "Ann2",
+        "unitIndexB": 5,
+        "positional": 0.07438016682863235,
+        "categorical": 1.0,
+        "combined": 1.0743801593780518
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 5,
+        "annotatorB": "Ann2",
+        "unitIndexB": 6,
+        "positional": 4.371901035308838,
+        "categorical": 1.0,
+        "combined": 5.371901035308838
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 5,
+        "annotatorB": "Ann2",
+        "unitIndexB": 7,
+        "positional": 15.280991554260254,
+        "categorical": 0.0,
+        "combined": 15.280991554260254
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 5,
+        "annotatorB": "Ann2",
+        "unitIndexB": 8,
+        "positional": 32.80165100097656,
+        "categorical": 1.0,
+        "combined": 33.80165100097656
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 5,
+        "annotatorB": "Ann2",
+        "unitIndexB": 9,
+        "positional": 56.93388366699219,
+        "categorical": 1.0,
+        "combined": 57.93388366699219
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 5,
+        "annotatorB": "Ann2",
+        "unitIndexB": 10,
+        "positional": 87.67768859863281,
+        "categorical": 0.0,
+        "combined": 87.67768859863281
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 5,
+        "annotatorB": "Ann2",
+        "unitIndexB": 11,
+        "positional": 125.0330581665039,
+        "categorical": 1.0,
+        "combined": 126.0330581665039
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 5,
+        "annotatorB": "Ann2",
+        "unitIndexB": 12,
+        "positional": 169.0,
+        "categorical": 1.0,
+        "combined": 170.0
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 5,
+        "annotatorB": "Ann2",
+        "unitIndexB": 13,
+        "positional": 219.57850646972656,
+        "categorical": 0.0,
+        "combined": 219.57850646972656
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 5,
+        "annotatorB": "Ann2",
+        "unitIndexB": 14,
+        "positional": 276.7685852050781,
+        "categorical": 1.0,
+        "combined": 277.7685852050781
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 5,
+        "annotatorB": "Ann2",
+        "unitIndexB": 15,
+        "positional": 340.57025146484375,
+        "categorical": 1.0,
+        "combined": 341.57025146484375
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 6,
+        "annotatorB": "Ann2",
+        "unitIndexB": 0,
+        "positional": 113.13223266601562,
+        "categorical": 1.0,
+        "combined": 114.13223266601562
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 6,
+        "annotatorB": "Ann2",
+        "unitIndexB": 1,
+        "positional": 77.76033020019531,
+        "categorical": 1.0,
+        "combined": 78.76033020019531
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 6,
+        "annotatorB": "Ann2",
+        "unitIndexB": 2,
+        "positional": 49.0,
+        "categorical": 0.0,
+        "combined": 49.0
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 6,
+        "annotatorB": "Ann2",
+        "unitIndexB": 3,
+        "positional": 26.851240158081055,
+        "categorical": 1.0,
+        "combined": 27.851240158081055
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 6,
+        "annotatorB": "Ann2",
+        "unitIndexB": 4,
+        "positional": 11.31404972076416,
+        "categorical": 1.0,
+        "combined": 12.31404972076416
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 6,
+        "annotatorB": "Ann2",
+        "unitIndexB": 5,
+        "positional": 2.388429641723633,
+        "categorical": 0.0,
+        "combined": 2.388429641723633
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 6,
+        "annotatorB": "Ann2",
+        "unitIndexB": 6,
+        "positional": 0.07438016682863235,
+        "categorical": 1.0,
+        "combined": 1.0743801593780518
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 6,
+        "annotatorB": "Ann2",
+        "unitIndexB": 7,
+        "positional": 4.371901035308838,
+        "categorical": 1.0,
+        "combined": 5.371901035308838
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 6,
+        "annotatorB": "Ann2",
+        "unitIndexB": 8,
+        "positional": 15.280991554260254,
+        "categorical": 0.0,
+        "combined": 15.280991554260254
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 6,
+        "annotatorB": "Ann2",
+        "unitIndexB": 9,
+        "positional": 32.80165100097656,
+        "categorical": 1.0,
+        "combined": 33.80165100097656
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 6,
+        "annotatorB": "Ann2",
+        "unitIndexB": 10,
+        "positional": 56.93388366699219,
+        "categorical": 1.0,
+        "combined": 57.93388366699219
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 6,
+        "annotatorB": "Ann2",
+        "unitIndexB": 11,
+        "positional": 87.67768859863281,
+        "categorical": 0.0,
+        "combined": 87.67768859863281
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 6,
+        "annotatorB": "Ann2",
+        "unitIndexB": 12,
+        "positional": 125.0330581665039,
+        "categorical": 1.0,
+        "combined": 126.0330581665039
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 6,
+        "annotatorB": "Ann2",
+        "unitIndexB": 13,
+        "positional": 169.0,
+        "categorical": 1.0,
+        "combined": 170.0
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 6,
+        "annotatorB": "Ann2",
+        "unitIndexB": 14,
+        "positional": 219.57850646972656,
+        "categorical": 0.0,
+        "combined": 219.57850646972656
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 6,
+        "annotatorB": "Ann2",
+        "unitIndexB": 15,
+        "positional": 276.7685852050781,
+        "categorical": 1.0,
+        "combined": 277.7685852050781
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 7,
+        "annotatorB": "Ann2",
+        "unitIndexB": 0,
+        "positional": 155.11570739746094,
+        "categorical": 0.0,
+        "combined": 155.11570739746094
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 7,
+        "annotatorB": "Ann2",
+        "unitIndexB": 1,
+        "positional": 113.13223266601562,
+        "categorical": 1.0,
+        "combined": 114.13223266601562
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 7,
+        "annotatorB": "Ann2",
+        "unitIndexB": 2,
+        "positional": 77.76033020019531,
+        "categorical": 1.0,
+        "combined": 78.76033020019531
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 7,
+        "annotatorB": "Ann2",
+        "unitIndexB": 3,
+        "positional": 49.0,
+        "categorical": 0.0,
+        "combined": 49.0
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 7,
+        "annotatorB": "Ann2",
+        "unitIndexB": 4,
+        "positional": 26.851240158081055,
+        "categorical": 1.0,
+        "combined": 27.851240158081055
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 7,
+        "annotatorB": "Ann2",
+        "unitIndexB": 5,
+        "positional": 11.31404972076416,
+        "categorical": 1.0,
+        "combined": 12.31404972076416
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 7,
+        "annotatorB": "Ann2",
+        "unitIndexB": 6,
+        "positional": 2.388429641723633,
+        "categorical": 0.0,
+        "combined": 2.388429641723633
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 7,
+        "annotatorB": "Ann2",
+        "unitIndexB": 7,
+        "positional": 0.07438016682863235,
+        "categorical": 1.0,
+        "combined": 1.0743801593780518
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 7,
+        "annotatorB": "Ann2",
+        "unitIndexB": 8,
+        "positional": 4.371901035308838,
+        "categorical": 1.0,
+        "combined": 5.371901035308838
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 7,
+        "annotatorB": "Ann2",
+        "unitIndexB": 9,
+        "positional": 15.280991554260254,
+        "categorical": 0.0,
+        "combined": 15.280991554260254
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 7,
+        "annotatorB": "Ann2",
+        "unitIndexB": 10,
+        "positional": 32.80165100097656,
+        "categorical": 1.0,
+        "combined": 33.80165100097656
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 7,
+        "annotatorB": "Ann2",
+        "unitIndexB": 11,
+        "positional": 56.93388366699219,
+        "categorical": 1.0,
+        "combined": 57.93388366699219
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 7,
+        "annotatorB": "Ann2",
+        "unitIndexB": 12,
+        "positional": 87.67768859863281,
+        "categorical": 0.0,
+        "combined": 87.67768859863281
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 7,
+        "annotatorB": "Ann2",
+        "unitIndexB": 13,
+        "positional": 125.0330581665039,
+        "categorical": 1.0,
+        "combined": 126.0330581665039
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 7,
+        "annotatorB": "Ann2",
+        "unitIndexB": 14,
+        "positional": 169.0,
+        "categorical": 1.0,
+        "combined": 170.0
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 7,
+        "annotatorB": "Ann2",
+        "unitIndexB": 15,
+        "positional": 219.57850646972656,
+        "categorical": 0.0,
+        "combined": 219.57850646972656
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 8,
+        "annotatorB": "Ann2",
+        "unitIndexB": 0,
+        "positional": 203.7107391357422,
+        "categorical": 1.0,
+        "combined": 204.7107391357422
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 8,
+        "annotatorB": "Ann2",
+        "unitIndexB": 1,
+        "positional": 155.11570739746094,
+        "categorical": 0.0,
+        "combined": 155.11570739746094
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 8,
+        "annotatorB": "Ann2",
+        "unitIndexB": 2,
+        "positional": 113.13223266601562,
+        "categorical": 1.0,
+        "combined": 114.13223266601562
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 8,
+        "annotatorB": "Ann2",
+        "unitIndexB": 3,
+        "positional": 77.76033020019531,
+        "categorical": 1.0,
+        "combined": 78.76033020019531
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 8,
+        "annotatorB": "Ann2",
+        "unitIndexB": 4,
+        "positional": 49.0,
+        "categorical": 0.0,
+        "combined": 49.0
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 8,
+        "annotatorB": "Ann2",
+        "unitIndexB": 5,
+        "positional": 26.851240158081055,
+        "categorical": 1.0,
+        "combined": 27.851240158081055
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 8,
+        "annotatorB": "Ann2",
+        "unitIndexB": 6,
+        "positional": 11.31404972076416,
+        "categorical": 1.0,
+        "combined": 12.31404972076416
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 8,
+        "annotatorB": "Ann2",
+        "unitIndexB": 7,
+        "positional": 2.388429641723633,
+        "categorical": 0.0,
+        "combined": 2.388429641723633
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 8,
+        "annotatorB": "Ann2",
+        "unitIndexB": 8,
+        "positional": 0.07438016682863235,
+        "categorical": 1.0,
+        "combined": 1.0743801593780518
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 8,
+        "annotatorB": "Ann2",
+        "unitIndexB": 9,
+        "positional": 4.371901035308838,
+        "categorical": 1.0,
+        "combined": 5.371901035308838
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 8,
+        "annotatorB": "Ann2",
+        "unitIndexB": 10,
+        "positional": 15.280991554260254,
+        "categorical": 0.0,
+        "combined": 15.280991554260254
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 8,
+        "annotatorB": "Ann2",
+        "unitIndexB": 11,
+        "positional": 32.80165100097656,
+        "categorical": 1.0,
+        "combined": 33.80165100097656
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 8,
+        "annotatorB": "Ann2",
+        "unitIndexB": 12,
+        "positional": 56.93388366699219,
+        "categorical": 1.0,
+        "combined": 57.93388366699219
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 8,
+        "annotatorB": "Ann2",
+        "unitIndexB": 13,
+        "positional": 87.67768859863281,
+        "categorical": 0.0,
+        "combined": 87.67768859863281
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 8,
+        "annotatorB": "Ann2",
+        "unitIndexB": 14,
+        "positional": 125.0330581665039,
+        "categorical": 1.0,
+        "combined": 126.0330581665039
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 8,
+        "annotatorB": "Ann2",
+        "unitIndexB": 15,
+        "positional": 169.0,
+        "categorical": 1.0,
+        "combined": 170.0
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 9,
+        "annotatorB": "Ann2",
+        "unitIndexB": 0,
+        "positional": 258.9173583984375,
+        "categorical": 1.0,
+        "combined": 259.9173583984375
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 9,
+        "annotatorB": "Ann2",
+        "unitIndexB": 1,
+        "positional": 203.7107391357422,
+        "categorical": 1.0,
+        "combined": 204.7107391357422
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 9,
+        "annotatorB": "Ann2",
+        "unitIndexB": 2,
+        "positional": 155.11570739746094,
+        "categorical": 0.0,
+        "combined": 155.11570739746094
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 9,
+        "annotatorB": "Ann2",
+        "unitIndexB": 3,
+        "positional": 113.13223266601562,
+        "categorical": 1.0,
+        "combined": 114.13223266601562
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 9,
+        "annotatorB": "Ann2",
+        "unitIndexB": 4,
+        "positional": 77.76033020019531,
+        "categorical": 1.0,
+        "combined": 78.76033020019531
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 9,
+        "annotatorB": "Ann2",
+        "unitIndexB": 5,
+        "positional": 49.0,
+        "categorical": 0.0,
+        "combined": 49.0
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 9,
+        "annotatorB": "Ann2",
+        "unitIndexB": 6,
+        "positional": 26.851240158081055,
+        "categorical": 1.0,
+        "combined": 27.851240158081055
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 9,
+        "annotatorB": "Ann2",
+        "unitIndexB": 7,
+        "positional": 11.31404972076416,
+        "categorical": 1.0,
+        "combined": 12.31404972076416
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 9,
+        "annotatorB": "Ann2",
+        "unitIndexB": 8,
+        "positional": 2.388429641723633,
+        "categorical": 0.0,
+        "combined": 2.388429641723633
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 9,
+        "annotatorB": "Ann2",
+        "unitIndexB": 9,
+        "positional": 0.07438016682863235,
+        "categorical": 1.0,
+        "combined": 1.0743801593780518
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 9,
+        "annotatorB": "Ann2",
+        "unitIndexB": 10,
+        "positional": 4.371901035308838,
+        "categorical": 1.0,
+        "combined": 5.371901035308838
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 9,
+        "annotatorB": "Ann2",
+        "unitIndexB": 11,
+        "positional": 15.280991554260254,
+        "categorical": 0.0,
+        "combined": 15.280991554260254
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 9,
+        "annotatorB": "Ann2",
+        "unitIndexB": 12,
+        "positional": 32.80165100097656,
+        "categorical": 1.0,
+        "combined": 33.80165100097656
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 9,
+        "annotatorB": "Ann2",
+        "unitIndexB": 13,
+        "positional": 56.93388366699219,
+        "categorical": 1.0,
+        "combined": 57.93388366699219
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 9,
+        "annotatorB": "Ann2",
+        "unitIndexB": 14,
+        "positional": 87.67768859863281,
+        "categorical": 0.0,
+        "combined": 87.67768859863281
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 9,
+        "annotatorB": "Ann2",
+        "unitIndexB": 15,
+        "positional": 125.0330581665039,
+        "categorical": 1.0,
+        "combined": 126.0330581665039
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 10,
+        "annotatorB": "Ann2",
+        "unitIndexB": 0,
+        "positional": 320.73553466796875,
+        "categorical": 0.0,
+        "combined": 320.73553466796875
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 10,
+        "annotatorB": "Ann2",
+        "unitIndexB": 1,
+        "positional": 258.9173583984375,
+        "categorical": 1.0,
+        "combined": 259.9173583984375
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 10,
+        "annotatorB": "Ann2",
+        "unitIndexB": 2,
+        "positional": 203.7107391357422,
+        "categorical": 1.0,
+        "combined": 204.7107391357422
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 10,
+        "annotatorB": "Ann2",
+        "unitIndexB": 3,
+        "positional": 155.11570739746094,
+        "categorical": 0.0,
+        "combined": 155.11570739746094
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 10,
+        "annotatorB": "Ann2",
+        "unitIndexB": 4,
+        "positional": 113.13223266601562,
+        "categorical": 1.0,
+        "combined": 114.13223266601562
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 10,
+        "annotatorB": "Ann2",
+        "unitIndexB": 5,
+        "positional": 77.76033020019531,
+        "categorical": 1.0,
+        "combined": 78.76033020019531
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 10,
+        "annotatorB": "Ann2",
+        "unitIndexB": 6,
+        "positional": 49.0,
+        "categorical": 0.0,
+        "combined": 49.0
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 10,
+        "annotatorB": "Ann2",
+        "unitIndexB": 7,
+        "positional": 26.851240158081055,
+        "categorical": 1.0,
+        "combined": 27.851240158081055
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 10,
+        "annotatorB": "Ann2",
+        "unitIndexB": 8,
+        "positional": 11.31404972076416,
+        "categorical": 1.0,
+        "combined": 12.31404972076416
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 10,
+        "annotatorB": "Ann2",
+        "unitIndexB": 9,
+        "positional": 2.388429641723633,
+        "categorical": 0.0,
+        "combined": 2.388429641723633
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 10,
+        "annotatorB": "Ann2",
+        "unitIndexB": 10,
+        "positional": 0.07438016682863235,
+        "categorical": 1.0,
+        "combined": 1.0743801593780518
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 10,
+        "annotatorB": "Ann2",
+        "unitIndexB": 11,
+        "positional": 4.371901035308838,
+        "categorical": 1.0,
+        "combined": 5.371901035308838
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 10,
+        "annotatorB": "Ann2",
+        "unitIndexB": 12,
+        "positional": 15.280991554260254,
+        "categorical": 0.0,
+        "combined": 15.280991554260254
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 10,
+        "annotatorB": "Ann2",
+        "unitIndexB": 13,
+        "positional": 32.80165100097656,
+        "categorical": 1.0,
+        "combined": 33.80165100097656
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 10,
+        "annotatorB": "Ann2",
+        "unitIndexB": 14,
+        "positional": 56.93388366699219,
+        "categorical": 1.0,
+        "combined": 57.93388366699219
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 10,
+        "annotatorB": "Ann2",
+        "unitIndexB": 15,
+        "positional": 87.67768859863281,
+        "categorical": 0.0,
+        "combined": 87.67768859863281
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 11,
+        "annotatorB": "Ann2",
+        "unitIndexB": 0,
+        "positional": 389.165283203125,
+        "categorical": 1.0,
+        "combined": 390.165283203125
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 11,
+        "annotatorB": "Ann2",
+        "unitIndexB": 1,
+        "positional": 320.73553466796875,
+        "categorical": 0.0,
+        "combined": 320.73553466796875
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 11,
+        "annotatorB": "Ann2",
+        "unitIndexB": 2,
+        "positional": 258.9173583984375,
+        "categorical": 1.0,
+        "combined": 259.9173583984375
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 11,
+        "annotatorB": "Ann2",
+        "unitIndexB": 3,
+        "positional": 203.7107391357422,
+        "categorical": 1.0,
+        "combined": 204.7107391357422
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 11,
+        "annotatorB": "Ann2",
+        "unitIndexB": 4,
+        "positional": 155.11570739746094,
+        "categorical": 0.0,
+        "combined": 155.11570739746094
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 11,
+        "annotatorB": "Ann2",
+        "unitIndexB": 5,
+        "positional": 113.13223266601562,
+        "categorical": 1.0,
+        "combined": 114.13223266601562
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 11,
+        "annotatorB": "Ann2",
+        "unitIndexB": 6,
+        "positional": 77.76033020019531,
+        "categorical": 1.0,
+        "combined": 78.76033020019531
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 11,
+        "annotatorB": "Ann2",
+        "unitIndexB": 7,
+        "positional": 49.0,
+        "categorical": 0.0,
+        "combined": 49.0
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 11,
+        "annotatorB": "Ann2",
+        "unitIndexB": 8,
+        "positional": 26.851240158081055,
+        "categorical": 1.0,
+        "combined": 27.851240158081055
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 11,
+        "annotatorB": "Ann2",
+        "unitIndexB": 9,
+        "positional": 11.31404972076416,
+        "categorical": 1.0,
+        "combined": 12.31404972076416
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 11,
+        "annotatorB": "Ann2",
+        "unitIndexB": 10,
+        "positional": 2.388429641723633,
+        "categorical": 0.0,
+        "combined": 2.388429641723633
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 11,
+        "annotatorB": "Ann2",
+        "unitIndexB": 11,
+        "positional": 0.07438016682863235,
+        "categorical": 1.0,
+        "combined": 1.0743801593780518
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 11,
+        "annotatorB": "Ann2",
+        "unitIndexB": 12,
+        "positional": 4.371901035308838,
+        "categorical": 1.0,
+        "combined": 5.371901035308838
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 11,
+        "annotatorB": "Ann2",
+        "unitIndexB": 13,
+        "positional": 15.280991554260254,
+        "categorical": 0.0,
+        "combined": 15.280991554260254
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 11,
+        "annotatorB": "Ann2",
+        "unitIndexB": 14,
+        "positional": 32.80165100097656,
+        "categorical": 1.0,
+        "combined": 33.80165100097656
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 11,
+        "annotatorB": "Ann2",
+        "unitIndexB": 15,
+        "positional": 56.93388366699219,
+        "categorical": 1.0,
+        "combined": 57.93388366699219
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 12,
+        "annotatorB": "Ann2",
+        "unitIndexB": 0,
+        "positional": 464.20660400390625,
+        "categorical": 1.0,
+        "combined": 465.20660400390625
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 12,
+        "annotatorB": "Ann2",
+        "unitIndexB": 1,
+        "positional": 389.165283203125,
+        "categorical": 1.0,
+        "combined": 390.165283203125
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 12,
+        "annotatorB": "Ann2",
+        "unitIndexB": 2,
+        "positional": 320.73553466796875,
+        "categorical": 0.0,
+        "combined": 320.73553466796875
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 12,
+        "annotatorB": "Ann2",
+        "unitIndexB": 3,
+        "positional": 258.9173583984375,
+        "categorical": 1.0,
+        "combined": 259.9173583984375
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 12,
+        "annotatorB": "Ann2",
+        "unitIndexB": 4,
+        "positional": 203.7107391357422,
+        "categorical": 1.0,
+        "combined": 204.7107391357422
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 12,
+        "annotatorB": "Ann2",
+        "unitIndexB": 5,
+        "positional": 155.11570739746094,
+        "categorical": 0.0,
+        "combined": 155.11570739746094
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 12,
+        "annotatorB": "Ann2",
+        "unitIndexB": 6,
+        "positional": 113.13223266601562,
+        "categorical": 1.0,
+        "combined": 114.13223266601562
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 12,
+        "annotatorB": "Ann2",
+        "unitIndexB": 7,
+        "positional": 77.76033020019531,
+        "categorical": 1.0,
+        "combined": 78.76033020019531
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 12,
+        "annotatorB": "Ann2",
+        "unitIndexB": 8,
+        "positional": 49.0,
+        "categorical": 0.0,
+        "combined": 49.0
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 12,
+        "annotatorB": "Ann2",
+        "unitIndexB": 9,
+        "positional": 26.851240158081055,
+        "categorical": 1.0,
+        "combined": 27.851240158081055
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 12,
+        "annotatorB": "Ann2",
+        "unitIndexB": 10,
+        "positional": 11.31404972076416,
+        "categorical": 1.0,
+        "combined": 12.31404972076416
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 12,
+        "annotatorB": "Ann2",
+        "unitIndexB": 11,
+        "positional": 2.388429641723633,
+        "categorical": 0.0,
+        "combined": 2.388429641723633
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 12,
+        "annotatorB": "Ann2",
+        "unitIndexB": 12,
+        "positional": 0.07438016682863235,
+        "categorical": 1.0,
+        "combined": 1.0743801593780518
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 12,
+        "annotatorB": "Ann2",
+        "unitIndexB": 13,
+        "positional": 4.371901035308838,
+        "categorical": 1.0,
+        "combined": 5.371901035308838
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 12,
+        "annotatorB": "Ann2",
+        "unitIndexB": 14,
+        "positional": 15.280991554260254,
+        "categorical": 0.0,
+        "combined": 15.280991554260254
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 12,
+        "annotatorB": "Ann2",
+        "unitIndexB": 15,
+        "positional": 32.80165100097656,
+        "categorical": 1.0,
+        "combined": 33.80165100097656
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 13,
+        "annotatorB": "Ann2",
+        "unitIndexB": 0,
+        "positional": 545.8594970703125,
+        "categorical": 0.0,
+        "combined": 545.8594970703125
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 13,
+        "annotatorB": "Ann2",
+        "unitIndexB": 1,
+        "positional": 464.20660400390625,
+        "categorical": 1.0,
+        "combined": 465.20660400390625
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 13,
+        "annotatorB": "Ann2",
+        "unitIndexB": 2,
+        "positional": 389.165283203125,
+        "categorical": 1.0,
+        "combined": 390.165283203125
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 13,
+        "annotatorB": "Ann2",
+        "unitIndexB": 3,
+        "positional": 320.73553466796875,
+        "categorical": 0.0,
+        "combined": 320.73553466796875
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 13,
+        "annotatorB": "Ann2",
+        "unitIndexB": 4,
+        "positional": 258.9173583984375,
+        "categorical": 1.0,
+        "combined": 259.9173583984375
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 13,
+        "annotatorB": "Ann2",
+        "unitIndexB": 5,
+        "positional": 203.7107391357422,
+        "categorical": 1.0,
+        "combined": 204.7107391357422
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 13,
+        "annotatorB": "Ann2",
+        "unitIndexB": 6,
+        "positional": 155.11570739746094,
+        "categorical": 0.0,
+        "combined": 155.11570739746094
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 13,
+        "annotatorB": "Ann2",
+        "unitIndexB": 7,
+        "positional": 113.13223266601562,
+        "categorical": 1.0,
+        "combined": 114.13223266601562
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 13,
+        "annotatorB": "Ann2",
+        "unitIndexB": 8,
+        "positional": 77.76033020019531,
+        "categorical": 1.0,
+        "combined": 78.76033020019531
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 13,
+        "annotatorB": "Ann2",
+        "unitIndexB": 9,
+        "positional": 49.0,
+        "categorical": 0.0,
+        "combined": 49.0
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 13,
+        "annotatorB": "Ann2",
+        "unitIndexB": 10,
+        "positional": 26.851240158081055,
+        "categorical": 1.0,
+        "combined": 27.851240158081055
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 13,
+        "annotatorB": "Ann2",
+        "unitIndexB": 11,
+        "positional": 11.31404972076416,
+        "categorical": 1.0,
+        "combined": 12.31404972076416
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 13,
+        "annotatorB": "Ann2",
+        "unitIndexB": 12,
+        "positional": 2.388429641723633,
+        "categorical": 0.0,
+        "combined": 2.388429641723633
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 13,
+        "annotatorB": "Ann2",
+        "unitIndexB": 13,
+        "positional": 0.07438016682863235,
+        "categorical": 1.0,
+        "combined": 1.0743801593780518
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 13,
+        "annotatorB": "Ann2",
+        "unitIndexB": 14,
+        "positional": 4.371901035308838,
+        "categorical": 1.0,
+        "combined": 5.371901035308838
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 13,
+        "annotatorB": "Ann2",
+        "unitIndexB": 15,
+        "positional": 15.280991554260254,
+        "categorical": 0.0,
+        "combined": 15.280991554260254
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 14,
+        "annotatorB": "Ann2",
+        "unitIndexB": 0,
+        "positional": 634.1239624023438,
+        "categorical": 1.0,
+        "combined": 635.1239624023438
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 14,
+        "annotatorB": "Ann2",
+        "unitIndexB": 1,
+        "positional": 545.8594970703125,
+        "categorical": 0.0,
+        "combined": 545.8594970703125
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 14,
+        "annotatorB": "Ann2",
+        "unitIndexB": 2,
+        "positional": 464.20660400390625,
+        "categorical": 1.0,
+        "combined": 465.20660400390625
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 14,
+        "annotatorB": "Ann2",
+        "unitIndexB": 3,
+        "positional": 389.165283203125,
+        "categorical": 1.0,
+        "combined": 390.165283203125
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 14,
+        "annotatorB": "Ann2",
+        "unitIndexB": 4,
+        "positional": 320.73553466796875,
+        "categorical": 0.0,
+        "combined": 320.73553466796875
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 14,
+        "annotatorB": "Ann2",
+        "unitIndexB": 5,
+        "positional": 258.9173583984375,
+        "categorical": 1.0,
+        "combined": 259.9173583984375
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 14,
+        "annotatorB": "Ann2",
+        "unitIndexB": 6,
+        "positional": 203.7107391357422,
+        "categorical": 1.0,
+        "combined": 204.7107391357422
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 14,
+        "annotatorB": "Ann2",
+        "unitIndexB": 7,
+        "positional": 155.11570739746094,
+        "categorical": 0.0,
+        "combined": 155.11570739746094
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 14,
+        "annotatorB": "Ann2",
+        "unitIndexB": 8,
+        "positional": 113.13223266601562,
+        "categorical": 1.0,
+        "combined": 114.13223266601562
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 14,
+        "annotatorB": "Ann2",
+        "unitIndexB": 9,
+        "positional": 77.76033020019531,
+        "categorical": 1.0,
+        "combined": 78.76033020019531
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 14,
+        "annotatorB": "Ann2",
+        "unitIndexB": 10,
+        "positional": 49.0,
+        "categorical": 0.0,
+        "combined": 49.0
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 14,
+        "annotatorB": "Ann2",
+        "unitIndexB": 11,
+        "positional": 26.851240158081055,
+        "categorical": 1.0,
+        "combined": 27.851240158081055
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 14,
+        "annotatorB": "Ann2",
+        "unitIndexB": 12,
+        "positional": 11.31404972076416,
+        "categorical": 1.0,
+        "combined": 12.31404972076416
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 14,
+        "annotatorB": "Ann2",
+        "unitIndexB": 13,
+        "positional": 2.388429641723633,
+        "categorical": 0.0,
+        "combined": 2.388429641723633
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 14,
+        "annotatorB": "Ann2",
+        "unitIndexB": 14,
+        "positional": 0.07438016682863235,
+        "categorical": 1.0,
+        "combined": 1.0743801593780518
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 14,
+        "annotatorB": "Ann2",
+        "unitIndexB": 15,
+        "positional": 4.371901035308838,
+        "categorical": 1.0,
+        "combined": 5.371901035308838
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 15,
+        "annotatorB": "Ann2",
+        "unitIndexB": 0,
+        "positional": 729.0,
+        "categorical": 1.0,
+        "combined": 730.0
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 15,
+        "annotatorB": "Ann2",
+        "unitIndexB": 1,
+        "positional": 634.1239624023438,
+        "categorical": 1.0,
+        "combined": 635.1239624023438
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 15,
+        "annotatorB": "Ann2",
+        "unitIndexB": 2,
+        "positional": 545.8594970703125,
+        "categorical": 0.0,
+        "combined": 545.8594970703125
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 15,
+        "annotatorB": "Ann2",
+        "unitIndexB": 3,
+        "positional": 464.20660400390625,
+        "categorical": 1.0,
+        "combined": 465.20660400390625
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 15,
+        "annotatorB": "Ann2",
+        "unitIndexB": 4,
+        "positional": 389.165283203125,
+        "categorical": 1.0,
+        "combined": 390.165283203125
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 15,
+        "annotatorB": "Ann2",
+        "unitIndexB": 5,
+        "positional": 320.73553466796875,
+        "categorical": 0.0,
+        "combined": 320.73553466796875
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 15,
+        "annotatorB": "Ann2",
+        "unitIndexB": 6,
+        "positional": 258.9173583984375,
+        "categorical": 1.0,
+        "combined": 259.9173583984375
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 15,
+        "annotatorB": "Ann2",
+        "unitIndexB": 7,
+        "positional": 203.7107391357422,
+        "categorical": 1.0,
+        "combined": 204.7107391357422
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 15,
+        "annotatorB": "Ann2",
+        "unitIndexB": 8,
+        "positional": 155.11570739746094,
+        "categorical": 0.0,
+        "combined": 155.11570739746094
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 15,
+        "annotatorB": "Ann2",
+        "unitIndexB": 9,
+        "positional": 113.13223266601562,
+        "categorical": 1.0,
+        "combined": 114.13223266601562
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 15,
+        "annotatorB": "Ann2",
+        "unitIndexB": 10,
+        "positional": 77.76033020019531,
+        "categorical": 1.0,
+        "combined": 78.76033020019531
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 15,
+        "annotatorB": "Ann2",
+        "unitIndexB": 11,
+        "positional": 49.0,
+        "categorical": 0.0,
+        "combined": 49.0
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 15,
+        "annotatorB": "Ann2",
+        "unitIndexB": 12,
+        "positional": 26.851240158081055,
+        "categorical": 1.0,
+        "combined": 27.851240158081055
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 15,
+        "annotatorB": "Ann2",
+        "unitIndexB": 13,
+        "positional": 11.31404972076416,
+        "categorical": 1.0,
+        "combined": 12.31404972076416
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 15,
+        "annotatorB": "Ann2",
+        "unitIndexB": 14,
+        "positional": 2.388429641723633,
+        "categorical": 0.0,
+        "combined": 2.388429641723633
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 15,
+        "annotatorB": "Ann2",
+        "unitIndexB": 15,
+        "positional": 0.07438016682863235,
+        "categorical": 1.0,
+        "combined": 1.0743801593780518
+      }
+    ],
+    "bestAlignmentDisorder": 1.0743801593780518
+  },
+  "tier2": {
+    "sampledContinua": [
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 3.8045281964531283,
+            "end": 10.519913789957018,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 14.414272267887991,
+            "end": 18.971391064025074,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 23.348114798455438,
+            "end": 28.941916411373956,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 32.74758512540097,
+            "end": 37.94493620130577,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 40.30864889175751,
+            "end": 46.38434439650109,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 52.684070115535484,
+            "end": 57.728941040038066,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 60.78184435677879,
+            "end": 65.84590476515096,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 69.54593875006363,
+            "end": 75.37155297663902,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 78.45553730140887,
+            "end": 83.98510942301839,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 87.75264558138804,
+            "end": 94.37201705386423,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 98.83638396846499,
+            "end": 104.73291062819597,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 108.19455006437268,
+            "end": 113.88328205523867,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 118.03782362074122,
+            "end": 123.63665366626248,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 129.34059463902187,
+            "end": 134.59684418846928,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 138.76087313186974,
+            "end": 144.10794662128643,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 147.74500947113674,
+            "end": 153.81184294137353,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 5.481006680224553,
+            "end": 11.228226879285097,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 15.120759914393073,
+            "end": 20.250314624343552,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 26.043825231253628,
+            "end": 31.654452292679128,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 35.272693950183836,
+            "end": 40.20077395922391,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 43.72405598096033,
+            "end": 49.80015836614817,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 57.02092193170881,
+            "end": 62.41583652085238,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 66.10082316832782,
+            "end": 72.08691282316741,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 76.51184107591699,
+            "end": 80.81157247441728,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 86.3492721138899,
+            "end": 91.81247545451548,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 97.57200338836395,
+            "end": 102.94907657623526,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 104.98971391545328,
+            "end": 111.25909198815779,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 115.20388438842643,
+            "end": 120.02779398262157,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 122.88150697239828,
+            "end": 127.68296996006416,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 131.73856185528376,
+            "end": 137.51054095377722,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 141.01005156197016,
+            "end": 146.38834171134704,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 151.42333815195818,
+            "end": 157.07645494483384,
+            "category": "c"
+          }
+        ],
+        "bestAlignmentDisorder": 0.9675393104553223,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 380453,
+              "end": 1051991,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1441427,
+              "end": 1897139,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 2334811,
+              "end": 2894192,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 3274759,
+              "end": 3794494,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 4030865,
+              "end": 4638434,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 5268407,
+              "end": 5772894,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 6078184,
+              "end": 6584590,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 6954594,
+              "end": 7537155,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 7845554,
+              "end": 8398511,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 8775265,
+              "end": 9437202,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 9883638,
+              "end": 10473291,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 10819455,
+              "end": 11388328,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 11803782,
+              "end": 12363665,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 12934059,
+              "end": 13459684,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 13876087,
+              "end": 14410795,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 14774501,
+              "end": 15381184,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 548101,
+              "end": 1122823,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1512076,
+              "end": 2025031,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 2604383,
+              "end": 3165445,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 3527269,
+              "end": 4020077,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 4372406,
+              "end": 4980016,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 5702092,
+              "end": 6241584,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 6610082,
+              "end": 7208691,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 7651184,
+              "end": 8081157,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 8634927,
+              "end": 9181248,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 9757200,
+              "end": 10294908,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 10498971,
+              "end": 11125909,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 11520388,
+              "end": 12002779,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 12288151,
+              "end": 12768297,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 13173856,
+              "end": 13751054,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 14101005,
+              "end": 14638834,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 15142334,
+              "end": 15707645,
+              "category": "c"
+            }
+          ],
+          "bestAlignmentDisorder": 0.9675394296646118
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 5.067722975607583,
+            "end": 11.076933542201557,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 16.469006763578946,
+            "end": 21.93408613694755,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 26.41504447097574,
+            "end": 31.534664316677897,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 34.90554575348176,
+            "end": 41.071668841847085,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 45.009698630374054,
+            "end": 50.286983634624754,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 53.91904198726019,
+            "end": 59.602068239188405,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 65.23303190116955,
+            "end": 69.85616147093103,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 74.75670434600659,
+            "end": 80.35167389817732,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 83.48289704870966,
+            "end": 88.36670399130803,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 93.37746423247077,
+            "end": 97.81206375909434,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 102.78827508140778,
+            "end": 107.12046417093582,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 109.97123914233752,
+            "end": 115.7518552120723,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 119.97138640730992,
+            "end": 124.73075680657192,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 128.8932523065438,
+            "end": 134.8100154696999,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 139.9152274928081,
+            "end": 145.2274170707688,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 147.78782005617697,
+            "end": 152.7563960205811,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 2.2505269253706883,
+            "end": 7.902351158024808,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 11.214186480219833,
+            "end": 16.50628874006894,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 21.74575015294793,
+            "end": 28.06572718605731,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 34.1892765575358,
+            "end": 40.753665197408935,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 45.787458660063244,
+            "end": 52.01900639989992,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 54.328804539435275,
+            "end": 60.42235801199129,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 62.78004602774454,
+            "end": 68.71862243383791,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 72.66596184737773,
+            "end": 77.87647618298803,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 81.04409125873767,
+            "end": 85.8936155328899,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 90.74443743827533,
+            "end": 96.89110068122528,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 101.42139358595212,
+            "end": 107.18231833111028,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 111.53163809449838,
+            "end": 118.14507022097656,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 121.58985042793704,
+            "end": 127.36413434636532,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 132.48852309942106,
+            "end": 138.3838234404835,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 141.9837985674737,
+            "end": 147.7424282448318,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 151.63586387514613,
+            "end": 157.26479618558056,
+            "category": "c"
+          }
+        ],
+        "bestAlignmentDisorder": 1.0580790042877197,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 506772,
+              "end": 1107693,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1646901,
+              "end": 2193409,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 2641504,
+              "end": 3153466,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 3490555,
+              "end": 4107167,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 4500970,
+              "end": 5028698,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 5391904,
+              "end": 5960207,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 6523303,
+              "end": 6985616,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 7475670,
+              "end": 8035167,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 8348290,
+              "end": 8836670,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 9337746,
+              "end": 9781206,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 10278828,
+              "end": 10712046,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 10997124,
+              "end": 11575186,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 11997139,
+              "end": 12473076,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 12889325,
+              "end": 13481002,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 13991523,
+              "end": 14522742,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 14778782,
+              "end": 15275640,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 225053,
+              "end": 790235,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1121419,
+              "end": 1650629,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 2174575,
+              "end": 2806573,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 3418928,
+              "end": 4075367,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 4578746,
+              "end": 5201901,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 5432880,
+              "end": 6042236,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 6278005,
+              "end": 6871862,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 7266596,
+              "end": 7787648,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 8104409,
+              "end": 8589362,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 9074444,
+              "end": 9689110,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 10142139,
+              "end": 10718232,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 11153164,
+              "end": 11814507,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 12158985,
+              "end": 12736413,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 13248852,
+              "end": 13838382,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 14198380,
+              "end": 14774243,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 15163586,
+              "end": 15726480,
+              "category": "c"
+            }
+          ],
+          "bestAlignmentDisorder": 1.0580782890319824
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 4.686919534182566,
+            "end": 10.42077214149695,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 14.71815340499727,
+            "end": 19.155822270097694,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 23.292835942559396,
+            "end": 29.27096687124978,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 32.72469387672291,
+            "end": 38.04669603763744,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 40.49306345596684,
+            "end": 46.231236544140245,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 49.940768812987336,
+            "end": 55.70302346908228,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 59.39874117638923,
+            "end": 65.31671315477533,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 69.8262566282515,
+            "end": 76.22399705811378,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 80.89380416747889,
+            "end": 86.64361318941155,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 89.51232981474284,
+            "end": 94.57521254887739,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 97.59540185867594,
+            "end": 103.19262054757579,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 107.40664211844008,
+            "end": 113.0645623850311,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 118.1406991745006,
+            "end": 123.12591242738301,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 125.7839752162663,
+            "end": 131.15304325708811,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 135.0688962670899,
+            "end": 140.00825246664098,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 145.86954993463854,
+            "end": 151.0728883754205,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 3.9166351975641653,
+            "end": 10.084210365877116,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 14.74279412738668,
+            "end": 20.597449092312768,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 24.389724938091028,
+            "end": 29.424274697827613,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 34.475502865876635,
+            "end": 39.9158439113692,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 44.077874226099695,
+            "end": 49.514045115122904,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 52.294514224754444,
+            "end": 57.04520392270281,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 60.79860436322177,
+            "end": 66.31592630110566,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 69.40025169252348,
+            "end": 74.93122250182894,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 77.04961624740864,
+            "end": 82.42185737627311,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 88.2415673313755,
+            "end": 93.59412918049387,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 99.15385631821235,
+            "end": 105.00048317036851,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 107.8415136760787,
+            "end": 111.87593945896465,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 117.03800867492126,
+            "end": 122.39426037011765,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 127.43599936715302,
+            "end": 133.24208848305503,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 138.23567130168033,
+            "end": 144.33424854682136,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 150.10846385652957,
+            "end": 155.30467414323954,
+            "category": "c"
+          }
+        ],
+        "bestAlignmentDisorder": 0.7922568321228027,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 468692,
+              "end": 1042077,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1471815,
+              "end": 1915582,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 2329284,
+              "end": 2927097,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 3272469,
+              "end": 3804670,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 4049306,
+              "end": 4623124,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 4994077,
+              "end": 5570302,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 5939874,
+              "end": 6531671,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 6982626,
+              "end": 7622400,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 8089380,
+              "end": 8664361,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 8951233,
+              "end": 9457521,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 9759540,
+              "end": 10319262,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 10740664,
+              "end": 11306456,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 11814070,
+              "end": 12312591,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 12578398,
+              "end": 13115304,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 13506890,
+              "end": 14000825,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 14586955,
+              "end": 15107289,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 391664,
+              "end": 1008421,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1474279,
+              "end": 2059745,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 2438972,
+              "end": 2942427,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 3447550,
+              "end": 3991584,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 4407787,
+              "end": 4951405,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 5229451,
+              "end": 5704520,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 6079860,
+              "end": 6631593,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 6940025,
+              "end": 7493122,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 7704962,
+              "end": 8242186,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 8824157,
+              "end": 9359413,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 9915386,
+              "end": 10500048,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 10784151,
+              "end": 11187594,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 11703801,
+              "end": 12239426,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 12743600,
+              "end": 13324209,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 13823567,
+              "end": 14433425,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 15010846,
+              "end": 15530467,
+              "category": "c"
+            }
+          ],
+          "bestAlignmentDisorder": 0.7922565937042236
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 3.5317471060176273,
+            "end": 9.753222111066021,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 12.516517336679254,
+            "end": 17.799466352541682,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 22.84774607492481,
+            "end": 28.372218389981164,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 30.24333814681699,
+            "end": 36.912542357595406,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 40.78080936177158,
+            "end": 45.92326874078261,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 50.04665982585192,
+            "end": 54.63711042422544,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 58.294246266753156,
+            "end": 63.15513841724814,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 66.20490534673606,
+            "end": 71.62862490904602,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 76.73085450638585,
+            "end": 82.40389624066367,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 86.00837089307618,
+            "end": 92.31900867269795,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 96.60511452494424,
+            "end": 101.86713910962106,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 107.20169271168865,
+            "end": 112.4457010074363,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 116.74921085001574,
+            "end": 121.55904473512402,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 128.13751093583832,
+            "end": 133.0720614834928,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 137.94240448835436,
+            "end": 143.84281391373085,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 147.7702510884423,
+            "end": 153.6411277020785,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 3.184316922732179,
+            "end": 8.405777232423416,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 13.318636252552238,
+            "end": 18.69656583171838,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 19.133747623452827,
+            "end": 24.244400997091198,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 27.798331306218547,
+            "end": 33.617999770392125,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 39.100321165718704,
+            "end": 44.47645669410967,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 49.3319846831252,
+            "end": 54.349253106340115,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 58.10930749816337,
+            "end": 63.95143090625342,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 67.54017738307633,
+            "end": 72.64806036196279,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 78.2644551289879,
+            "end": 83.19500999986644,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 85.4121401235689,
+            "end": 91.80009827507219,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 94.1236003297031,
+            "end": 100.19103201737698,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 102.19274670365316,
+            "end": 107.41845062289353,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 110.53491444919509,
+            "end": 116.49084565569659,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 122.21470479503792,
+            "end": 128.0516236995112,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 132.39402655203833,
+            "end": 137.78902725152744,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 141.44689656519378,
+            "end": 146.90065723431638,
+            "category": "a"
+          }
+        ],
+        "bestAlignmentDisorder": 1.0783107280731201,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 353175,
+              "end": 975322,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1251652,
+              "end": 1779947,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 2284775,
+              "end": 2837222,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 3024334,
+              "end": 3691254,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 4078081,
+              "end": 4592327,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 5004666,
+              "end": 5463711,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 5829425,
+              "end": 6315514,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 6620491,
+              "end": 7162862,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 7673085,
+              "end": 8240390,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 8600837,
+              "end": 9231901,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 9660511,
+              "end": 10186714,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 10720169,
+              "end": 11244570,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 11674921,
+              "end": 12155904,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 12813751,
+              "end": 13307206,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 13794240,
+              "end": 14384281,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 14777025,
+              "end": 15364113,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 318432,
+              "end": 840578,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1331864,
+              "end": 1869657,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1913375,
+              "end": 2424440,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 2779833,
+              "end": 3361800,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 3910032,
+              "end": 4447646,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 4933198,
+              "end": 5434925,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 5810931,
+              "end": 6395143,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 6754018,
+              "end": 7264806,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 7826446,
+              "end": 8319501,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 8541214,
+              "end": 9180010,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 9412360,
+              "end": 10019103,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 10219275,
+              "end": 10741845,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 11053491,
+              "end": 11649085,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 12221470,
+              "end": 12805162,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 13239403,
+              "end": 13778903,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 14144690,
+              "end": 14690066,
+              "category": "a"
+            }
+          ],
+          "bestAlignmentDisorder": 1.0783106088638306
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 3.740145690137748,
+            "end": 8.811711615977734,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 13.92322915273784,
+            "end": 18.9747138417368,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 23.143018685570517,
+            "end": 28.36827001938882,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 32.97323725032444,
+            "end": 38.21128946496696,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 43.95027975575115,
+            "end": 50.20710263974999,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 54.54976709202255,
+            "end": 59.56772356402575,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 63.45379504602684,
+            "end": 68.98649982566693,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 74.63524722728523,
+            "end": 80.23398173491294,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 86.35258428044213,
+            "end": 92.04049167314783,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 95.96462096400231,
+            "end": 101.25769903277082,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 103.90794534802043,
+            "end": 110.07991841535092,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 114.55996918612536,
+            "end": 119.99014137054567,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 123.16850276550345,
+            "end": 129.063799571952,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 134.53587886722298,
+            "end": 140.38124616442448,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 143.50287572171231,
+            "end": 149.27045329802317,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 152.91159727600737,
+            "end": 158.02589988810323,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 4.621379449132699,
+            "end": 9.906784452905413,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 12.598855580002892,
+            "end": 17.392073060802403,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 22.40626166760655,
+            "end": 27.49932073381471,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 31.03799511283136,
+            "end": 36.763130287426584,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 43.172618267006605,
+            "end": 47.95230151800099,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 51.24919215666856,
+            "end": 56.81184200541281,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 60.97199669978267,
+            "end": 66.92982799744097,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 71.86266816534464,
+            "end": 76.66241774378037,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 79.62478532538755,
+            "end": 84.78769042559485,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 91.32232494737752,
+            "end": 97.20535617022249,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 100.1813545212112,
+            "end": 106.26163402693525,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 110.05986765284469,
+            "end": 115.34178971427914,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 119.40378575876163,
+            "end": 125.55219617270829,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 129.22166866092184,
+            "end": 135.48440714135967,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 139.89693336191928,
+            "end": 145.73628313662488,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 149.49664620308604,
+            "end": 155.92789942234938,
+            "category": "c"
+          }
+        ],
+        "bestAlignmentDisorder": 0.857323944568634,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 374015,
+              "end": 881171,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1392323,
+              "end": 1897471,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 2314302,
+              "end": 2836827,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 3297324,
+              "end": 3821129,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 4395028,
+              "end": 5020710,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 5454977,
+              "end": 5956772,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 6345380,
+              "end": 6898650,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 7463525,
+              "end": 8023398,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 8635258,
+              "end": 9204049,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 9596462,
+              "end": 10125770,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 10390795,
+              "end": 11007992,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 11455997,
+              "end": 11999014,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 12316850,
+              "end": 12906380,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 13453588,
+              "end": 14038125,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 14350288,
+              "end": 14927045,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 15291160,
+              "end": 15802590,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 462138,
+              "end": 990678,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1259886,
+              "end": 1739207,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 2240626,
+              "end": 2749932,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 3103800,
+              "end": 3676313,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 4317262,
+              "end": 4795230,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 5124919,
+              "end": 5681184,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 6097200,
+              "end": 6692983,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 7186267,
+              "end": 7666242,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 7962479,
+              "end": 8478769,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 9132232,
+              "end": 9720536,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 10018135,
+              "end": 10626163,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 11005987,
+              "end": 11534179,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 11940379,
+              "end": 12555220,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 12922167,
+              "end": 13548441,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 13989693,
+              "end": 14573628,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 14949665,
+              "end": 15592790,
+              "category": "c"
+            }
+          ],
+          "bestAlignmentDisorder": 0.8573242425918579
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 2.8038307869005408,
+            "end": 8.26993324457286,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 12.191551809670859,
+            "end": 17.046800522977538,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 21.98396044822689,
+            "end": 27.928901532356246,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 31.8986446087036,
+            "end": 36.50556722137709,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 41.073666482289426,
+            "end": 47.04152043432018,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 49.87789948394613,
+            "end": 55.874601405377824,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 61.790282018587,
+            "end": 66.91305131944017,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 73.569040455673,
+            "end": 79.40066222281123,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 83.90090167272902,
+            "end": 89.63052457757767,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 93.84963006960751,
+            "end": 99.25404129854567,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 102.74526811245421,
+            "end": 108.69650787387751,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 111.54817129800831,
+            "end": 116.12016171583248,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 120.39685197218745,
+            "end": 126.51912236250703,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 128.6224665184656,
+            "end": 134.49725185693362,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 137.98847230672362,
+            "end": 144.0196492213432,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 148.7414033945979,
+            "end": 154.13932837240685,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 4.374192097763153,
+            "end": 10.507830508974,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 15.683910265716122,
+            "end": 20.982756775053172,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 26.540427118129376,
+            "end": 31.290194497244677,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 34.61137932777913,
+            "end": 40.78053970947673,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 46.01346893817649,
+            "end": 51.315673129648836,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 55.922674116944016,
+            "end": 61.847874564493296,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 65.48044569799184,
+            "end": 70.63623763145561,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 74.57838193647063,
+            "end": 79.16149737687516,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 84.18054691772358,
+            "end": 90.15240174466558,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 93.52624635788919,
+            "end": 99.11203102489058,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 105.1730961801232,
+            "end": 111.36889999584712,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 114.22350054295106,
+            "end": 119.33715944478645,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 124.70280536537418,
+            "end": 130.37583129766685,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 131.80105945509652,
+            "end": 137.49400068690161,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 140.41177079088476,
+            "end": 144.96441915930856,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 147.4910487047126,
+            "end": 153.0101404090069,
+            "category": "c"
+          }
+        ],
+        "bestAlignmentDisorder": 1.052868127822876,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 280383,
+              "end": 826993,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1219155,
+              "end": 1704680,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 2198396,
+              "end": 2792890,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 3189864,
+              "end": 3650557,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 4107367,
+              "end": 4704152,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 4987790,
+              "end": 5587460,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 6179028,
+              "end": 6691305,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 7356904,
+              "end": 7940066,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 8390090,
+              "end": 8963052,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 9384963,
+              "end": 9925404,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 10274527,
+              "end": 10869651,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 11154817,
+              "end": 11612016,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 12039685,
+              "end": 12651912,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 12862247,
+              "end": 13449725,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 13798847,
+              "end": 14401965,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 14874140,
+              "end": 15413933,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 437419,
+              "end": 1050783,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1568391,
+              "end": 2098276,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 2654043,
+              "end": 3129019,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 3461138,
+              "end": 4078054,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 4601347,
+              "end": 5131567,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 5592267,
+              "end": 6184787,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 6548045,
+              "end": 7063624,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 7457838,
+              "end": 7916150,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 8418055,
+              "end": 9015240,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 9352625,
+              "end": 9911203,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 10517310,
+              "end": 11136890,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 11422350,
+              "end": 11933716,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 12470281,
+              "end": 13037583,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 13180106,
+              "end": 13749400,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 14041177,
+              "end": 14496442,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 14749105,
+              "end": 15301014,
+              "category": "c"
+            }
+          ],
+          "bestAlignmentDisorder": 1.0528686046600342
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 4.1964695618392405,
+            "end": 9.368303371787203,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 13.089043117445415,
+            "end": 19.127419499175858,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 22.746131812504192,
+            "end": 27.917257660411295,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 32.179868367786916,
+            "end": 37.78226052568011,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 42.884223374343655,
+            "end": 48.28498096407549,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 53.11479875866532,
+            "end": 59.74946461242685,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 62.632054034437026,
+            "end": 68.3025101191314,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 69.88940819795756,
+            "end": 74.69719333116645,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 79.80573306980963,
+            "end": 85.90215736618603,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 90.36461149263165,
+            "end": 95.25751765400463,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 100.62140371782746,
+            "end": 106.28955260731848,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 109.60289613237809,
+            "end": 114.79499272368271,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 116.8217879984167,
+            "end": 121.0671705756344,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 124.08472081311416,
+            "end": 129.44809407690377,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 133.97004843819823,
+            "end": 139.01953463649494,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 144.94852950409523,
+            "end": 150.41169921106894,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 1.8226652339609157,
+            "end": 6.811563852659818,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 10.381118085737667,
+            "end": 15.813709007102842,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 18.226447827105016,
+            "end": 23.806833864843426,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 28.90906089065472,
+            "end": 33.76425424178349,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 38.882190428797166,
+            "end": 44.27680084435852,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 50.23206488990459,
+            "end": 55.20037910295719,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 58.84536234000909,
+            "end": 64.21271925052659,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 67.1631605658606,
+            "end": 73.27724495060833,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 77.0638558845545,
+            "end": 82.29266267376032,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 84.85160021766845,
+            "end": 91.19890072166969,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 94.25201527696704,
+            "end": 100.01896736461411,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 104.53805889134678,
+            "end": 110.97105098822135,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 115.70516030137225,
+            "end": 121.2935077059479,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 125.92156497806847,
+            "end": 131.2744348209775,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 134.10245275931894,
+            "end": 139.25101333011233,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 142.740829057937,
+            "end": 148.2699004236347,
+            "category": "b"
+          }
+        ],
+        "bestAlignmentDisorder": 0.9391423463821411,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 419647,
+              "end": 936830,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1308904,
+              "end": 1912742,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 2274613,
+              "end": 2791726,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 3217987,
+              "end": 3778226,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 4288422,
+              "end": 4828498,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 5311480,
+              "end": 5974946,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 6263205,
+              "end": 6830251,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 6988941,
+              "end": 7469719,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 7980573,
+              "end": 8590216,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 9036461,
+              "end": 9525752,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 10062140,
+              "end": 10628955,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 10960290,
+              "end": 11479499,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 11682179,
+              "end": 12106717,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 12408472,
+              "end": 12944809,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 13397005,
+              "end": 13901953,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 14494853,
+              "end": 15041170,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 182267,
+              "end": 681156,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1038112,
+              "end": 1581371,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1822645,
+              "end": 2380683,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 2890906,
+              "end": 3376425,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 3888219,
+              "end": 4427680,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 5023206,
+              "end": 5520038,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 5884536,
+              "end": 6421272,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 6716316,
+              "end": 7327724,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 7706386,
+              "end": 8229266,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 8485160,
+              "end": 9119890,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 9425202,
+              "end": 10001897,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 10453806,
+              "end": 11097105,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 11570516,
+              "end": 12129351,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 12592156,
+              "end": 13127443,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 13410245,
+              "end": 13925101,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 14274083,
+              "end": 14826990,
+              "category": "b"
+            }
+          ],
+          "bestAlignmentDisorder": 0.9391425251960754
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 3.8939997498563548,
+            "end": 8.279269023806895,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 12.508436213693582,
+            "end": 17.425285224111796,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 21.707427233102436,
+            "end": 27.92934003439132,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 32.515627673325035,
+            "end": 38.706468875555146,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 43.066909082277554,
+            "end": 49.00198734368828,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 53.45432126148624,
+            "end": 57.67147706115703,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 62.860729668097754,
+            "end": 67.7324960447942,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 73.99326062814791,
+            "end": 79.13674416636874,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 83.27934360261428,
+            "end": 89.4923553477077,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 94.82941562787684,
+            "end": 99.77024461305153,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 104.22101882427877,
+            "end": 109.77915866316808,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 112.55176140888035,
+            "end": 118.37681613558698,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 122.111233096557,
+            "end": 127.28850413998858,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 131.99519255654013,
+            "end": 137.64271183223283,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 141.7486156986397,
+            "end": 147.51628557003988,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 152.7903007548933,
+            "end": 158.64406336775085,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 2.3131570548624873,
+            "end": 7.552839265097211,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 10.716868074484776,
+            "end": 16.110462188482327,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 19.235309533195636,
+            "end": 24.950051650233476,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 29.184613045066985,
+            "end": 35.004936321999466,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 39.28401938209071,
+            "end": 44.917667858629564,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 49.017891767403604,
+            "end": 54.817081370204676,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 59.42215375916272,
+            "end": 64.70235610829053,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 68.66133845079482,
+            "end": 74.18868777952208,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 79.90199287787974,
+            "end": 85.6039522774987,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 91.38826065128231,
+            "end": 97.97680905607116,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 103.30013323774075,
+            "end": 109.12783139478638,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 113.32690498042308,
+            "end": 118.88667663148537,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 123.27077579144355,
+            "end": 128.35401444207673,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 131.9946192034604,
+            "end": 138.06714413458033,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 142.20081042222373,
+            "end": 147.68306973965923,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 151.71135837764953,
+            "end": 156.84783198127147,
+            "category": "a"
+          }
+        ],
+        "bestAlignmentDisorder": 0.9769284725189209,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 389400,
+              "end": 827927,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1250844,
+              "end": 1742529,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 2170743,
+              "end": 2792934,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 3251563,
+              "end": 3870647,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 4306691,
+              "end": 4900199,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 5345432,
+              "end": 5767148,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 6286073,
+              "end": 6773250,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 7399326,
+              "end": 7913674,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 8327934,
+              "end": 8949236,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 9482942,
+              "end": 9977024,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 10422102,
+              "end": 10977916,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 11255176,
+              "end": 11837682,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 12211123,
+              "end": 12728850,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 13199519,
+              "end": 13764271,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 14174862,
+              "end": 14751629,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 15279030,
+              "end": 15864406,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 231316,
+              "end": 755284,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1071687,
+              "end": 1611046,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1923531,
+              "end": 2495005,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 2918461,
+              "end": 3500494,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 3928402,
+              "end": 4491767,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 4901789,
+              "end": 5481708,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 5942215,
+              "end": 6470236,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 6866134,
+              "end": 7418869,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 7990199,
+              "end": 8560395,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 9138826,
+              "end": 9797681,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 10330013,
+              "end": 10912783,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 11332690,
+              "end": 11888668,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 12327078,
+              "end": 12835401,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 13199462,
+              "end": 13806714,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 14220081,
+              "end": 14768307,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 15171136,
+              "end": 15684783,
+              "category": "a"
+            }
+          ],
+          "bestAlignmentDisorder": 0.9769285321235657
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 3.4138178007302336,
+            "end": 9.237070954867681,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 14.332037359083927,
+            "end": 20.73035612036147,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 24.667785102978062,
+            "end": 29.372364140846276,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 33.793579275638706,
+            "end": 40.01417025235643,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 44.48227203141416,
+            "end": 50.09777072286784,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 54.313423845267934,
+            "end": 60.01042149660757,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 65.72714477487061,
+            "end": 70.8462466357811,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 75.04833091663022,
+            "end": 80.32224913097035,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 84.67285991408667,
+            "end": 90.47922368537633,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 97.2061508825585,
+            "end": 102.30984534536483,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 106.12706939019749,
+            "end": 111.71023437307257,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 115.96604807773477,
+            "end": 122.05098910423771,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 128.88071547792757,
+            "end": 134.5655838861595,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 137.41480932052417,
+            "end": 142.996992645407,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 146.94728950854443,
+            "end": 152.53821559364246,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 160.11971827319778,
+            "end": 165.58136377244668,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 6.7449883891801,
+            "end": 10.714094330619808,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 15.46092042253325,
+            "end": 21.29957407094777,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 27.360875169885823,
+            "end": 33.11758191555191,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 37.44861693233706,
+            "end": 42.76983550990569,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 48.106113235855254,
+            "end": 53.275820941196535,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 57.134902538254295,
+            "end": 62.67843056368239,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 70.45815397656436,
+            "end": 76.35366495163251,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 79.99457479110139,
+            "end": 86.23109155303284,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 91.01930890178953,
+            "end": 97.56704190756236,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 99.72539906428494,
+            "end": 105.21988702403601,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 109.05448974363503,
+            "end": 115.4700746058393,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 121.35972513911308,
+            "end": 127.2458524824061,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 130.2607718855768,
+            "end": 136.37210552814895,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 141.7525924018569,
+            "end": 147.01116292044094,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 149.63922538307935,
+            "end": 155.53304205320703,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 158.44655866846477,
+            "end": 163.70623199253967,
+            "category": "a"
+          }
+        ],
+        "bestAlignmentDisorder": 1.1310679912567139,
+        "scaled": {
+          "scale": 10000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 34138,
+              "end": 92371,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 143320,
+              "end": 207304,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 246678,
+              "end": 293724,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 337936,
+              "end": 400142,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 444823,
+              "end": 500978,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 543134,
+              "end": 600104,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 657271,
+              "end": 708462,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 750483,
+              "end": 803222,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 846729,
+              "end": 904792,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 972062,
+              "end": 1023098,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1061271,
+              "end": 1117102,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1159660,
+              "end": 1220510,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1288807,
+              "end": 1345656,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1374148,
+              "end": 1429970,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1469473,
+              "end": 1525382,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1601197,
+              "end": 1655814,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 67450,
+              "end": 107141,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 154609,
+              "end": 212996,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 273609,
+              "end": 331176,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 374486,
+              "end": 427698,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 481061,
+              "end": 532758,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 571349,
+              "end": 626784,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 704582,
+              "end": 763537,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 799946,
+              "end": 862311,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 910193,
+              "end": 975670,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 997254,
+              "end": 1052199,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1090545,
+              "end": 1154701,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1213597,
+              "end": 1272459,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1302608,
+              "end": 1363721,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1417526,
+              "end": 1470112,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1496392,
+              "end": 1555330,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1584466,
+              "end": 1637062,
+              "category": "a"
+            }
+          ],
+          "bestAlignmentDisorder": 1.131066083908081
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 6.630057737902864,
+            "end": 12.22141754787951,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 15.70901621703336,
+            "end": 20.71286201391643,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 24.964528325552894,
+            "end": 29.94254176505116,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 34.1413224981971,
+            "end": 39.62952415762232,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 44.921019909564606,
+            "end": 50.3351853619725,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 53.461327258413014,
+            "end": 59.39071079262848,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 63.02675623571694,
+            "end": 67.86929110393262,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 72.76375511407461,
+            "end": 78.80099322720439,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 83.1870109219107,
+            "end": 89.24960480116495,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 93.22910486805004,
+            "end": 99.97471559553782,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 103.52432528068431,
+            "end": 109.00389019221262,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 115.12586596317847,
+            "end": 121.53305023271808,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 126.22734612907018,
+            "end": 130.46628643814012,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 135.6400100228369,
+            "end": 142.23315887147172,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 147.8529339540193,
+            "end": 153.9902957651398,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 159.25749116823792,
+            "end": 165.17233184086967,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 2.673560064351473,
+            "end": 8.424250547644643,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 12.210100555921223,
+            "end": 18.237981990035525,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 22.113740966348182,
+            "end": 27.84751489285023,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 31.560572996203955,
+            "end": 37.75618222895014,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 40.82126425621175,
+            "end": 45.81596015977333,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 49.524828136092424,
+            "end": 54.94454419069338,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 59.36181513709331,
+            "end": 64.86351425916932,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 67.79928018639319,
+            "end": 73.74459252090651,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 78.03345813857705,
+            "end": 83.90045084665059,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 88.14592735653518,
+            "end": 93.89746129614993,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 97.92470947342055,
+            "end": 103.79709420283228,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 105.82832008487767,
+            "end": 111.24485604235193,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 113.74089051584596,
+            "end": 119.14881585365455,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 123.06381450950518,
+            "end": 128.2840456161535,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 131.77286897719623,
+            "end": 137.2116917131976,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 140.28337946344612,
+            "end": 145.78295336098958,
+            "category": "c"
+          }
+        ],
+        "bestAlignmentDisorder": 1.1647920608520508,
+        "scaled": {
+          "scale": 10000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 66301,
+              "end": 122214,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 157090,
+              "end": 207129,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 249645,
+              "end": 299425,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 341413,
+              "end": 396295,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 449210,
+              "end": 503352,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 534613,
+              "end": 593907,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 630268,
+              "end": 678693,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 727638,
+              "end": 788010,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 831870,
+              "end": 892496,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 932291,
+              "end": 999747,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1035243,
+              "end": 1090039,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1151259,
+              "end": 1215331,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1262273,
+              "end": 1304663,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1356400,
+              "end": 1422332,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1478529,
+              "end": 1539903,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1592575,
+              "end": 1651723,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 26736,
+              "end": 84243,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 122101,
+              "end": 182380,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 221137,
+              "end": 278475,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 315606,
+              "end": 377562,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 408213,
+              "end": 458160,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 495248,
+              "end": 549445,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 593618,
+              "end": 648635,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 677993,
+              "end": 737446,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 780335,
+              "end": 839005,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 881459,
+              "end": 938975,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 979247,
+              "end": 1037971,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1058283,
+              "end": 1112449,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1137409,
+              "end": 1191488,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1230638,
+              "end": 1282840,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1317729,
+              "end": 1372117,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1402834,
+              "end": 1457830,
+              "category": "c"
+            }
+          ],
+          "bestAlignmentDisorder": 1.164791464805603
+        }
+      }
+    ]
+  },
+  "tier3": {
+    "expectedDisorder": 0.9759838581085205,
+    "gamma": -0.10081756114959717,
+    "nSamples": 30
+  }
+}

--- a/dkpro-statistics-agreement/src/test/resources/pygamma/fixture_06_weighted_alpha3_beta2.json
+++ b/dkpro-statistics-agreement/src/test/resources/pygamma/fixture_06_weighted_alpha3_beta2.json
@@ -1,0 +1,978 @@
+{
+  "metadata": {
+    "pygammaVersion": "0.5.9",
+    "pygammaRepo": "https://github.com/bootphon/pygamma-agreement",
+    "pygammaCommit": "44587ef",
+    "solver": "GLPK_MI",
+    "seed": 6,
+    "description": "2 annotators, 3 units each, with alpha=3 and beta=2 to exercise positional/categorical weighting."
+  },
+  "params": {
+    "alpha": 3.0,
+    "beta": 2.0,
+    "deltaEmpty": 1.0
+  },
+  "continuum": [
+    {
+      "annotator": "Ann1",
+      "start": 1,
+      "end": 5,
+      "category": "a"
+    },
+    {
+      "annotator": "Ann1",
+      "start": 6,
+      "end": 10,
+      "category": "b"
+    },
+    {
+      "annotator": "Ann1",
+      "start": 11,
+      "end": 15,
+      "category": "c"
+    },
+    {
+      "annotator": "Ann2",
+      "start": 2,
+      "end": 7,
+      "category": "a"
+    },
+    {
+      "annotator": "Ann2",
+      "start": 8,
+      "end": 12,
+      "category": "b"
+    },
+    {
+      "annotator": "Ann2",
+      "start": 11,
+      "end": 15,
+      "category": "a"
+    }
+  ],
+  "tier1": {
+    "pairDissimilarities": [
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 0,
+        "annotatorB": "Ann2",
+        "unitIndexB": 0,
+        "positional": 0.1111111119389534,
+        "categorical": 0.0,
+        "combined": 0.3333333432674408
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 0,
+        "annotatorB": "Ann2",
+        "unitIndexB": 1,
+        "positional": 3.0625,
+        "categorical": 1.0,
+        "combined": 11.1875
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 0,
+        "annotatorB": "Ann2",
+        "unitIndexB": 2,
+        "positional": 6.25,
+        "categorical": 0.0,
+        "combined": 18.75
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 1,
+        "annotatorB": "Ann2",
+        "unitIndexB": 0,
+        "positional": 0.604938268661499,
+        "categorical": 1.0,
+        "combined": 3.814814805984497
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 1,
+        "annotatorB": "Ann2",
+        "unitIndexB": 1,
+        "positional": 0.25,
+        "categorical": 0.0,
+        "combined": 0.75
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 1,
+        "annotatorB": "Ann2",
+        "unitIndexB": 2,
+        "positional": 1.5625,
+        "categorical": 1.0,
+        "combined": 6.6875
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 2,
+        "annotatorB": "Ann2",
+        "unitIndexB": 0,
+        "positional": 3.567901134490967,
+        "categorical": 1.0,
+        "combined": 12.703702926635742
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 2,
+        "annotatorB": "Ann2",
+        "unitIndexB": 1,
+        "positional": 0.5625,
+        "categorical": 1.0,
+        "combined": 3.6875
+      },
+      {
+        "annotatorA": "Ann1",
+        "unitIndexA": 2,
+        "annotatorB": "Ann2",
+        "unitIndexB": 2,
+        "positional": 0.0,
+        "categorical": 1.0,
+        "combined": 2.0
+      }
+    ],
+    "bestAlignmentDisorder": 1.0277777910232544
+  },
+  "tier2": {
+    "sampledContinua": [
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 1.3562688564194638,
+            "end": 5.604112537927884,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 5.52663052927221,
+            "end": 9.024100400781174,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 8.958338641013713,
+            "end": 13.735933023740033,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 2.3426931107899804,
+            "end": 6.883230848181554,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 7.301728943825867,
+            "end": 11.929673269788621,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 13.41647258135231,
+            "end": 17.81968660636665,
+            "category": "b"
+          }
+        ],
+        "bestAlignmentDisorder": 2.0,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 135627,
+              "end": 560411,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 552663,
+              "end": 902410,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 895834,
+              "end": 1373593,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 234269,
+              "end": 688323,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 730173,
+              "end": 1192967,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1341647,
+              "end": 1781969,
+              "category": "b"
+            }
+          ],
+          "bestAlignmentDisorder": 2.0
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 2.310508158870922,
+            "end": 5.971646140837439,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 6.277643371871072,
+            "end": 10.803408628940934,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 12.985923513322586,
+            "end": 17.08513300378992,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 2.018832653920781,
+            "end": 5.9670800511807816,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 6.782146391170419,
+            "end": 10.94063028499114,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 12.930542750665536,
+            "end": 16.77223932437969,
+            "category": "a"
+          }
+        ],
+        "bestAlignmentDisorder": 0.6703330874443054,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 231051,
+              "end": 597165,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 627764,
+              "end": 1080341,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1298592,
+              "end": 1708513,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 201883,
+              "end": 596708,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 678215,
+              "end": 1094063,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1293054,
+              "end": 1677224,
+              "category": "a"
+            }
+          ],
+          "bestAlignmentDisorder": 0.6703331470489502
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 0.25668621579771833,
+            "end": 4.1326073466722795,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 5.688432081155034,
+            "end": 9.087544540494031,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 9.486185783762993,
+            "end": 13.443604609241499,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 1.5022322813871136,
+            "end": 5.768454810235135,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 6.1520595843094785,
+            "end": 10.466443723882719,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 9.00439472686275,
+            "end": 12.941478063799625,
+            "category": "b"
+          }
+        ],
+        "bestAlignmentDisorder": 1.3903924226760864,
+        "scaled": {
+          "scale": 1000000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 256686,
+              "end": 4132607,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 5688432,
+              "end": 9087545,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 9486186,
+              "end": 13443605,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1502232,
+              "end": 5768455,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 6152060,
+              "end": 10466444,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 9004395,
+              "end": 12941478,
+              "category": "b"
+            }
+          ],
+          "bestAlignmentDisorder": 1.3903924226760864
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 1.5419241632217684,
+            "end": 5.867458013644605,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 5.914087468916846,
+            "end": 9.675799546881285,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 10.131895822420834,
+            "end": 14.465122878793428,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 0.7340497233656053,
+            "end": 4.620338631458074,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 6.172281250999845,
+            "end": 10.503633350450649,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 10.374207950585843,
+            "end": 14.62218708053933,
+            "category": "b"
+          }
+        ],
+        "bestAlignmentDisorder": 0.7472984194755554,
+        "scaled": {
+          "scale": 1000000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 1541924,
+              "end": 5867458,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 5914087,
+              "end": 9675800,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 10131896,
+              "end": 14465123,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 734050,
+              "end": 4620339,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 6172281,
+              "end": 10503633,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 10374208,
+              "end": 14622187,
+              "category": "b"
+            }
+          ],
+          "bestAlignmentDisorder": 0.7472983002662659
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": -0.5617830215197165,
+            "end": 3.591396515745878,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 4.225679596939663,
+            "end": 9.033501521186398,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 11.64423782785675,
+            "end": 15.609432144677754,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": -0.7384561504568254,
+            "end": 3.5941056488978727,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 4.768913028686338,
+            "end": 8.715000354335515,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 9.494617161873233,
+            "end": 13.45451779285892,
+            "category": "b"
+          }
+        ],
+        "bestAlignmentDisorder": 2.0,
+        "scaled": {
+          "scale": 1000000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": -561783,
+              "end": 3591397,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 4225680,
+              "end": 9033502,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 11644238,
+              "end": 15609432,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": -738456,
+              "end": 3594106,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 4768913,
+              "end": 8715000,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 9494617,
+              "end": 13454518,
+              "category": "b"
+            }
+          ],
+          "bestAlignmentDisorder": 2.0
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 2.1786359662061487,
+            "end": 6.356709720797848,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 6.809008539294815,
+            "end": 10.780685433260501,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 13.867022961264487,
+            "end": 18.076519492683108,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": -0.08356969932689452,
+            "end": 3.8734896842206745,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 4.1611577879685235,
+            "end": 8.83576140356504,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 8.074368407178111,
+            "end": 12.301626268555676,
+            "category": "c"
+          }
+        ],
+        "bestAlignmentDisorder": 1.6154909133911133,
+        "scaled": {
+          "scale": 100000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 217864,
+              "end": 635671,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 680901,
+              "end": 1078069,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 1386702,
+              "end": 1807652,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": -8357,
+              "end": 387349,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 416116,
+              "end": 883576,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 807437,
+              "end": 1230163,
+              "category": "c"
+            }
+          ],
+          "bestAlignmentDisorder": 1.615491509437561
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 0.43836402070098834,
+            "end": 4.58281253342671,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 5.468088816847375,
+            "end": 9.656766401838404,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 10.656997786928244,
+            "end": 14.842876356236479,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 0.42237706985002865,
+            "end": 4.246754781982433,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 4.376712269473708,
+            "end": 8.381734892420486,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 8.453451169718102,
+            "end": 12.14288735566942,
+            "category": "a"
+          }
+        ],
+        "bestAlignmentDisorder": 0.4730502665042877,
+        "scaled": {
+          "scale": 1000000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 438364,
+              "end": 4582813,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 5468089,
+              "end": 9656766,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 10656998,
+              "end": 14842876,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 422377,
+              "end": 4246755,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 4376712,
+              "end": 8381735,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 8453451,
+              "end": 12142887,
+              "category": "a"
+            }
+          ],
+          "bestAlignmentDisorder": 0.4730503559112549
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 0.44176351784531764,
+            "end": 4.642268215098645,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 5.5945589502272695,
+            "end": 9.582200199458379,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 9.663438726657636,
+            "end": 14.075050827381887,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 1.5196098879315543,
+            "end": 5.673400854325163,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 5.32973980305022,
+            "end": 9.828705823620348,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 10.388957533059008,
+            "end": 14.232055286269762,
+            "category": "a"
+          }
+        ],
+        "bestAlignmentDisorder": 2.0,
+        "scaled": {
+          "scale": 1000000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 441764,
+              "end": 4642268,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 5594559,
+              "end": 9582200,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 9663439,
+              "end": 14075051,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 1519610,
+              "end": 5673401,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 5329740,
+              "end": 9828706,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 10388958,
+              "end": 14232055,
+              "category": "a"
+            }
+          ],
+          "bestAlignmentDisorder": 2.0
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 0.013085164008055275,
+            "end": 3.8087807651004786,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 4.4225626134321665,
+            "end": 9.09499298623065,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 10.981333230853568,
+            "end": 15.669965788452165,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": -0.23270500779146497,
+            "end": 4.11764076830003,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 5.5211347277853315,
+            "end": 9.503915161050404,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 10.820223080591784,
+            "end": 14.965293178194123,
+            "category": "a"
+          }
+        ],
+        "bestAlignmentDisorder": 1.3636692762374878,
+        "scaled": {
+          "scale": 1000000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 13085,
+              "end": 3808781,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 4422563,
+              "end": 9094993,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 10981333,
+              "end": 15669966,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": -232705,
+              "end": 4117641,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 5521135,
+              "end": 9503915,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 10820223,
+              "end": 14965293,
+              "category": "a"
+            }
+          ],
+          "bestAlignmentDisorder": 1.3636690378189087
+        }
+      },
+      {
+        "units": [
+          {
+            "annotator": "Ann1",
+            "start": 0.3377808028454751,
+            "end": 4.482052277309554,
+            "category": "b"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 4.695709822355351,
+            "end": 8.381208404361168,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann1",
+            "start": 8.799173838953616,
+            "end": 12.846521572773653,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": -1.013532452690815,
+            "end": 3.008308686378366,
+            "category": "c"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 4.332425000188904,
+            "end": 8.857359444409319,
+            "category": "a"
+          },
+          {
+            "annotator": "Ann2",
+            "start": 10.49735595361373,
+            "end": 14.788652108095729,
+            "category": "c"
+          }
+        ],
+        "bestAlignmentDisorder": 2.0,
+        "scaled": {
+          "scale": 1000000,
+          "units": [
+            {
+              "annotator": "Ann1",
+              "start": 337781,
+              "end": 4482052,
+              "category": "b"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 4695710,
+              "end": 8381208,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann1",
+              "start": 8799174,
+              "end": 12846522,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": -1013532,
+              "end": 3008309,
+              "category": "c"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 4332425,
+              "end": 8857359,
+              "category": "a"
+            },
+            {
+              "annotator": "Ann2",
+              "start": 10497356,
+              "end": 14788652,
+              "category": "c"
+            }
+          ],
+          "bestAlignmentDisorder": 2.0
+        }
+      }
+    ]
+  },
+  "tier3": {
+    "expectedDisorder": 1.3599934577941895,
+    "gamma": 0.24427741765975952,
+    "nSamples": 30
+  }
+}

--- a/dkpro-statistics-agreement/src/test/scripts/generate_pygamma_fixtures.py
+++ b/dkpro-statistics-agreement/src/test/scripts/generate_pygamma_fixtures.py
@@ -1,0 +1,514 @@
+#!/usr/bin/env python3
+# =============================================================================
+# generate_pygamma_fixtures.py
+#
+# PURPOSE
+# -------
+# Generate JSON validation fixtures for the Java port of the gamma
+# inter-annotator-agreement measure (dkpro-statistics-agreement). The fixtures
+# are produced by running the reference implementation *pygamma-agreement* on
+# hand-crafted continua and dumping the intermediate + final results the Java
+# side will assert against. The validation strategy has three tiers (see
+# PLAN_pygamma.md sections 5 and 6):
+#
+#   tier1 - exact, deterministic core:
+#           * per-pair positional / categorical / combined dissimilarities
+#           * best-alignment disorder delta(a*) via the canonical fast=False ILP
+#   tier2 - exact via replay:
+#           * the actual sampled continua from StatisticalContinuumSampler plus
+#             each sample's best-alignment disorder. Additionally a
+#             scaled-integer replay variant (coordinates * 10^k, rounded to int,
+#             kept < 2^24) with the disorder RE-COMPUTED BY PYGAMMA on the
+#             scaled integer continuum. Java replays the scaled variant.
+#   tier3 - statistical reference only:
+#           * expected disorder / gamma / n_samples from compute_gamma with
+#             pygamma's own internal 30 samples. This is NOT expected to match
+#             tier2 (independent PRNG stream); it is a statistical sanity point.
+#
+# PROVENANCE
+# ----------
+# Reference implementation exercised through its PUBLIC API only (this script
+# copies no source logic from pygamma; it merely calls Continuum,
+# CombinedCategoricalDissimilarity, StatisticalContinuumSampler, etc.):
+#
+#   package : pygamma-agreement == 0.5.9  (installed from PyPI)
+#   repo    : https://github.com/bootphon/pygamma-agreement
+#   commit  : 44587ef  (2024-03-04, version 0.5.9) -- analyzed reference
+#   license : MIT
+#   authors : Rachid Riad, Hadrien Titeux, Leopold Favre  (CoML, 2020-2021)
+#
+# Because only the public API is used, the pygamma MIT copyright/permission
+# notice does not need to be reproduced here. If this script is ever modified to
+# copy algorithmic logic out of the pygamma sources, the original MIT copyright
+# and permission notice from the corresponding source file MUST be reproduced
+# verbatim in this header.
+#
+# ENVIRONMENT SETUP
+# -----------------
+# numba (a pygamma dependency) constrains the usable Python version. This
+# fixture set was generated with:
+#
+#   python  : 3.11 (CPython)   -- use an interpreter numba 0.66 supports
+#   pygamma : pygamma-agreement==0.5.9
+#   solver  : GLPK_MI (cvxpy) -- pygamma tries CBC (needs cylp) first and falls
+#             back to GLPK_MI; CBC/cylp is NOT installed here so GLPK_MI is used.
+#             GLPK_MI is an exact MIP solver, so the optimal disorder VALUE is
+#             identical to what CBC would return (only the value matters).
+#
+#   python3.11 -m venv pygamma-venv
+#   ./pygamma-venv/bin/pip install "pygamma-agreement==0.5.9"
+#   ./pygamma-venv/bin/python generate_pygamma_fixtures.py
+#
+# OUTPUT
+# ------
+# Pretty-printed JSON files, stable key order, written to
+#   dkpro-statistics-agreement/src/test/resources/pygamma/fixture_<nn>_<slug>.json
+#
+# UNIT ORDERING (documented so Java can reproduce indexes)
+# --------------------------------------------------------
+# pygamma stores each annotator's units in a SortedSet. Units sort by
+# (segment, annotation): first by segment start, then segment end, then
+# annotation alphabetically (a None annotation sorts first). Annotators are
+# processed in alphabetical order; categories are indexed alphabetically.
+# The unitIndexA / unitIndexB values below are positions in that sorted order.
+#
+# NOTE ON PRECISION
+# -----------------
+# pygamma computes in np.float32 essentially everywhere. The best-alignment
+# disorder comes from the njit float32 d_mat path. The tier1 per-pair
+# dissimilarities below are taken from the dissimilarity objects' .d() methods;
+# although those methods do their arithmetic in Python float, the final multiply
+# by delta_empty (stored as np.float32) rounds each returned value to float32
+# too -- e.g. d_pos of 1/9 comes out as 0.11111111 (float32), not the float64
+# 0.1111111111111111. So BOTH tier1 pair values and the disorders are float32.
+# Java will use double; assert with a relative tolerance of ~1e-5.
+# =============================================================================
+
+import json
+import logging
+import os
+from collections import OrderedDict
+
+import numpy as np
+
+# Silence the (expected, repeated) "CBC solver not installed. Using GLPK." warnings.
+logging.disable(logging.WARNING)
+
+from pyannote.core import Segment  # noqa: E402
+import pygamma_agreement  # noqa: E402
+from pygamma_agreement import (  # noqa: E402
+    Continuum,
+    CombinedCategoricalDissimilarity,
+    StatisticalContinuumSampler,
+)
+
+# --- provenance constants (also embedded in every fixture's metadata) --------
+PYGAMMA_VERSION = getattr(pygamma_agreement, "__version__", "0.5.9")
+PYGAMMA_REPO = "https://github.com/bootphon/pygamma-agreement"
+PYGAMMA_COMMIT = "44587ef"
+
+
+def detect_solver():
+    """Report which MIP solver pygamma's get_best_alignment will actually use."""
+    try:
+        import cylp  # noqa: F401
+        return "CBC"
+    except ImportError:
+        return "GLPK_MI"
+
+
+SOLVER = detect_solver()
+
+# float32 represents integers exactly only up to 2^24; keep scaled coords below.
+MAX_EXACT_INT = 1 << 24  # 16777216
+SCALE_MARGIN = 16_000_000  # a bit under 2^24 for safety
+TIER2_SAMPLES = 10
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+OUT_DIR = os.path.abspath(
+    os.path.join(HERE, "..", "resources", "pygamma")
+)
+
+
+# -----------------------------------------------------------------------------
+# Continuum construction / inspection helpers
+# -----------------------------------------------------------------------------
+def build_continuum(units):
+    """units: iterable of (annotator, start, end, category)."""
+    c = Continuum()
+    for annotator, start, end, category in units:
+        c.add(annotator, Segment(float(start), float(end)), category)
+    return c
+
+
+def continuum_to_units(continuum):
+    """Dump the continuum as a flat ordered list of unit dicts.
+
+    Annotators alphabetical; units in each annotator's SortedSet order.
+    """
+    out = []
+    for annotator in continuum.annotators:  # SortedSet -> alphabetical
+        for unit in continuum._annotations[annotator]:  # SortedSet order
+            out.append(
+                OrderedDict(
+                    [
+                        ("annotator", annotator),
+                        ("start", _num(unit.segment.start)),
+                        ("end", _num(unit.segment.end)),
+                        ("category", unit.annotation),
+                    ]
+                )
+            )
+    return out
+
+
+def _num(x):
+    """Emit ints as ints (clean JSON) when the value is integral, else float."""
+    xf = float(x)
+    if xf.is_integer():
+        return int(xf)
+    return xf
+
+
+def sorted_units_by_annotator(continuum):
+    """OrderedDict annotator -> list of Unit, in pygamma's sorted order."""
+    d = OrderedDict()
+    for annotator in continuum.annotators:
+        d[annotator] = list(continuum._annotations[annotator])
+    return d
+
+
+# -----------------------------------------------------------------------------
+# Tier 1
+# -----------------------------------------------------------------------------
+def tier1_pair_dissimilarities(continuum, dissim):
+    """Every inter-annotator unit pair with positional/categorical/combined d()."""
+    by_ann = sorted_units_by_annotator(continuum)
+    annotators = list(by_ann.keys())
+    pairs = []
+    for ia in range(len(annotators)):
+        for ib in range(ia + 1, len(annotators)):
+            ann_a, ann_b = annotators[ia], annotators[ib]
+            for idx_a, unit_a in enumerate(by_ann[ann_a]):
+                for idx_b, unit_b in enumerate(by_ann[ann_b]):
+                    positional = float(dissim.positional_dissim.d(unit_a, unit_b))
+                    categorical = float(dissim.categorical_dissim.d(unit_a, unit_b))
+                    combined = float(dissim.d(unit_a, unit_b))
+                    pairs.append(
+                        OrderedDict(
+                            [
+                                ("annotatorA", ann_a),
+                                ("unitIndexA", idx_a),
+                                ("annotatorB", ann_b),
+                                ("unitIndexB", idx_b),
+                                ("positional", positional),
+                                ("categorical", categorical),
+                                ("combined", combined),
+                            ]
+                        )
+                    )
+    return pairs
+
+
+def best_alignment_disorder(continuum, dissim):
+    """Canonical fast=False best-alignment disorder delta(a*)."""
+    return float(continuum.get_best_alignment(dissim).disorder)
+
+
+# -----------------------------------------------------------------------------
+# Tier 2
+# -----------------------------------------------------------------------------
+def choose_scale(sample_units):
+    """Largest power of ten in [1e6 .. 1] keeping all scaled coords < 2^24."""
+    max_coord = 0.0
+    for u in sample_units:
+        max_coord = max(max_coord, abs(u["start"]), abs(u["end"]))
+    for exp in (6, 5, 4, 3, 2, 1, 0):
+        scale = 10 ** exp
+        if max_coord * scale < SCALE_MARGIN:
+            return scale
+    return 1
+
+
+def scale_continuum(sample_units, scale):
+    """Build a Continuum with coordinates * scale rounded to int."""
+    scaled_units = []
+    for u in sample_units:
+        s = int(round(u["start"] * scale))
+        e = int(round(u["end"] * scale))
+        if e <= s:  # keep durations strictly positive (Segment rejects dur 0)
+            e = s + 1
+        scaled_units.append((u["annotator"], s, e, u["category"]))
+    return scaled_units
+
+
+def tier2_sampled_continua(continuum, dissim, seed):
+    """Draw TIER2_SAMPLES samples; dump raw + scaled-integer replay variants."""
+    sampler = StatisticalContinuumSampler()
+    sampler.init_sampling(continuum)
+    np.random.seed(seed)
+
+    samples = []
+    for _ in range(TIER2_SAMPLES):
+        sample = sampler.sample_from_continuum  # property -> fresh Continuum
+        raw_units = [
+            OrderedDict(
+                [
+                    ("annotator", annotator),
+                    ("start", float(unit.segment.start)),
+                    ("end", float(unit.segment.end)),
+                    ("category", unit.annotation),
+                ]
+            )
+            for annotator in sample.annotators
+            for unit in sample._annotations[annotator]
+        ]
+        raw_disorder = best_alignment_disorder(sample, dissim)
+
+        scale = choose_scale(raw_units)
+        scaled_unit_tuples = scale_continuum(raw_units, scale)
+        scaled_continuum = build_continuum(scaled_unit_tuples)
+        scaled_disorder = best_alignment_disorder(scaled_continuum, dissim)
+        scaled_units = [
+            OrderedDict(
+                [
+                    ("annotator", a),
+                    ("start", int(s)),
+                    ("end", int(e)),
+                    ("category", cat),
+                ]
+            )
+            for (a, s, e, cat) in scaled_unit_tuples
+        ]
+
+        samples.append(
+            OrderedDict(
+                [
+                    ("units", raw_units),
+                    ("bestAlignmentDisorder", raw_disorder),
+                    (
+                        "scaled",
+                        OrderedDict(
+                            [
+                                ("scale", int(scale)),
+                                ("units", scaled_units),
+                                ("bestAlignmentDisorder", scaled_disorder),
+                            ]
+                        ),
+                    ),
+                ]
+            )
+        )
+    return samples
+
+
+# -----------------------------------------------------------------------------
+# Tier 3
+# -----------------------------------------------------------------------------
+def tier3_gamma(continuum, dissim, seed):
+    """compute_gamma with precision_level=None (pygamma's own 30 samples)."""
+    np.random.seed(seed)
+    res = continuum.compute_gamma(dissim, precision_level=None)
+    return OrderedDict(
+        [
+            ("expectedDisorder", float(res.expected_disorder)),
+            ("gamma", float(res.gamma)),
+            ("nSamples", int(res.n_samples)),
+        ]
+    )
+
+
+# -----------------------------------------------------------------------------
+# Fixture assembly
+# -----------------------------------------------------------------------------
+def make_fixture(index, slug, description, units, seed, alpha=1.0, beta=1.0,
+                 delta_empty=1.0):
+    continuum = build_continuum(units)
+    dissim = CombinedCategoricalDissimilarity(
+        alpha=alpha, beta=beta, delta_empty=delta_empty
+    )
+
+    fixture = OrderedDict()
+    fixture["metadata"] = OrderedDict(
+        [
+            ("pygammaVersion", PYGAMMA_VERSION),
+            ("pygammaRepo", PYGAMMA_REPO),
+            ("pygammaCommit", PYGAMMA_COMMIT),
+            ("solver", SOLVER),
+            ("seed", seed),
+            ("description", description),
+        ]
+    )
+    fixture["params"] = OrderedDict(
+        [
+            ("alpha", float(alpha)),
+            ("beta", float(beta)),
+            ("deltaEmpty", float(delta_empty)),
+        ]
+    )
+    fixture["continuum"] = continuum_to_units(continuum)
+
+    fixture["tier1"] = OrderedDict(
+        [
+            ("pairDissimilarities", tier1_pair_dissimilarities(continuum, dissim)),
+            ("bestAlignmentDisorder", best_alignment_disorder(continuum, dissim)),
+        ]
+    )
+    fixture["tier2"] = OrderedDict(
+        [
+            ("sampledContinua", tier2_sampled_continua(continuum, dissim, seed)),
+        ]
+    )
+    fixture["tier3"] = tier3_gamma(continuum, dissim, seed + 1000)
+
+    path = os.path.join(OUT_DIR, f"fixture_{index:02d}_{slug}.json")
+    with open(path, "w") as f:
+        json.dump(fixture, f, indent=2, sort_keys=False)
+        f.write("\n")
+
+    print(
+        f"wrote {os.path.basename(path)}  "
+        f"tier1.bestAlignmentDisorder={fixture['tier1']['bestAlignmentDisorder']:.6g}  "
+        f"tier3.gamma={fixture['tier3']['gamma']:.6g}  "
+        f"(n={fixture['tier3']['nSamples']})"
+    )
+    return fixture
+
+
+# -----------------------------------------------------------------------------
+# Hand-crafted continua
+# -----------------------------------------------------------------------------
+def fixture_definitions():
+    defs = []
+
+    # 1) Two annotators, simple, categories, slight positional offset.
+    defs.append(
+        dict(
+            index=1,
+            slug="two_annotators_simple",
+            description="2 annotators, 3 units each, small positional offsets, "
+                        "nominal categories.",
+            seed=1,
+            units=[
+                ("Ann1", 1, 5, "a"),
+                ("Ann1", 6, 10, "b"),
+                ("Ann1", 11, 15, "a"),
+                ("Ann2", 2, 6, "a"),
+                ("Ann2", 7, 11, "b"),
+                ("Ann2", 12, 16, "a"),
+            ],
+        )
+    )
+
+    # 2) Two annotators, unequal unit counts -> forces empty units in alignment.
+    defs.append(
+        dict(
+            index=2,
+            slug="unequal_counts",
+            description="2 annotators with unequal unit counts (4 vs 2), forcing "
+                        "empty units in the best alignment.",
+            seed=2,
+            units=[
+                ("Ann1", 1, 5, "a"),
+                ("Ann1", 6, 10, "b"),
+                ("Ann1", 20, 24, "a"),
+                ("Ann1", 30, 34, "b"),
+                ("Ann2", 2, 6, "a"),
+                ("Ann2", 31, 35, "b"),
+            ],
+        )
+    )
+
+    # 3) Two annotators, identical annotations -> observed disorder 0 -> gamma 1.
+    defs.append(
+        dict(
+            index=3,
+            slug="identical_perfect",
+            description="2 annotators with identical annotations: observed "
+                        "disorder is 0, so gamma is 1.",
+            seed=3,
+            units=[
+                ("Ann1", 1, 5, "a"),
+                ("Ann1", 10, 15, "b"),
+                ("Ann1", 20, 25, "c"),
+                ("Ann2", 1, 5, "a"),
+                ("Ann2", 10, 15, "b"),
+                ("Ann2", 20, 25, "c"),
+            ],
+        )
+    )
+
+    # 4) Three annotators.
+    defs.append(
+        dict(
+            index=4,
+            slug="three_annotators",
+            description="3 annotators, 2 units each, with positional and one "
+                        "categorical disagreement.",
+            seed=4,
+            units=[
+                ("Ann1", 1, 5, "a"),
+                ("Ann1", 10, 14, "b"),
+                ("Ann2", 2, 6, "a"),
+                ("Ann2", 11, 15, "b"),
+                ("Ann3", 1, 4, "a"),
+                ("Ann3", 9, 14, "c"),
+            ],
+        )
+    )
+
+    # 5) Larger 2-annotator continuum, ~16 units each.
+    n = 16
+    larger = []
+    cats = ["a", "b", "c"]
+    for i in range(n):
+        start1 = 1 + i * 10
+        larger.append(("Ann1", start1, start1 + 5, cats[i % 3]))
+        start2 = 2 + i * 10  # 1-unit offset
+        larger.append(("Ann2", start2, start2 + 6, cats[(i + 1) % 3]))
+    defs.append(
+        dict(
+            index=5,
+            slug="larger_two_annotators",
+            description="2 annotators, 16 units each, regular offsets, cycling "
+                        "categories; a larger continuum for the ILP.",
+            seed=5,
+            units=larger,
+        )
+    )
+
+    # 6) alpha=3, beta=2 weighting to exercise the combined dissimilarity coeffs.
+    defs.append(
+        dict(
+            index=6,
+            slug="weighted_alpha3_beta2",
+            description="2 annotators, 3 units each, with alpha=3 and beta=2 to "
+                        "exercise positional/categorical weighting.",
+            seed=6,
+            alpha=3.0,
+            beta=2.0,
+            units=[
+                ("Ann1", 1, 5, "a"),
+                ("Ann1", 6, 10, "b"),
+                ("Ann1", 11, 15, "c"),
+                ("Ann2", 2, 7, "a"),
+                ("Ann2", 8, 12, "b"),
+                ("Ann2", 11, 15, "a"),
+            ],
+        )
+    )
+
+    return defs
+
+
+def main():
+    os.makedirs(OUT_DIR, exist_ok=True)
+    print(f"pygamma-agreement {PYGAMMA_VERSION} (commit {PYGAMMA_COMMIT}), "
+          f"solver {SOLVER}")
+    print(f"output dir: {OUT_DIR}")
+    for d in fixture_definitions():
+        make_fixture(**d)
+
+
+if __name__ == "__main__":
+    main()

--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,16 @@
         <version>3.14.0</version>
       </dependency>
       <dependency>
+        <groupId>org.ojalgo</groupId>
+        <artifactId>ojalgo</artifactId>
+        <version>57.0.0</version>
+      </dependency>
+      <dependency>
+        <groupId>com.fasterxml.jackson.core</groupId>
+        <artifactId>jackson-databind</artifactId>
+        <version>2.18.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>3.5.2</version>


### PR DESCRIPTION
**What's in the PR**
- Add support for the Mathet et al. (2015) Gamma (γ) inter-annotator agreement measure for continua of timed intervals, ported from the pygamma-agreement project

**How to test manually**
* No specific test procedure

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
