### PR TITLE
#37 - Upgrade dependencies

### DIFF
--- a/dkpro-statistics-agreement/pom.xml
+++ b/dkpro-statistics-agreement/pom.xml
@@ -62,7 +62,7 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
+      <groupId>tools.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
       <scope>test</scope>
     </dependency>

--- a/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/aligning/GammaAgreementFixtureTest.java
+++ b/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/aligning/GammaAgreementFixtureTest.java
@@ -28,7 +28,7 @@ import org.dkpro.statistics.agreement.aligning.dissimilarity.CombinedCategorical
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 /**
  * Cross-validation of {@link GammaAgreement} against pygamma-agreement fixtures.

--- a/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/aligning/PygammaFixtures.java
+++ b/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/aligning/PygammaFixtures.java
@@ -29,8 +29,8 @@ import org.dkpro.statistics.agreement.aligning.data.AnnotationSet;
 import org.dkpro.statistics.agreement.aligning.data.Rater;
 import org.dkpro.statistics.agreement.aligning.dissimilarity.CombinedCategoricalDissimilarity;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
 
 /**
  * Shared loader for the pygamma cross-validation fixtures under
@@ -93,11 +93,11 @@ public final class PygammaFixtures
         var raters = new HashMap<String, Rater>();
         var units = new ArrayList<AlignableAnnotationUnit>();
         for (JsonNode entry : aUnitsArray) {
-            String annotator = entry.get("annotator").asText();
+            String annotator = entry.get("annotator").asString();
             var rater = raters.computeIfAbsent(annotator, name -> new Rater(name, raters.size()));
             long start = entry.get("start").asLong();
             long end = entry.get("end").asLong();
-            String category = entry.get("category").asText();
+            String category = entry.get("category").asString();
             units.add(new AlignableAnnotationUnit(rater, null, start, end,
                     Map.of("category", category)));
         }

--- a/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/aligning/alignment/BestAlignmentFixtureTest.java
+++ b/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/aligning/alignment/BestAlignmentFixtureTest.java
@@ -23,7 +23,7 @@ import org.dkpro.statistics.agreement.aligning.PygammaFixtures;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import com.fasterxml.jackson.databind.JsonNode;
+import tools.jackson.databind.JsonNode;
 
 public class BestAlignmentFixtureTest
 {

--- a/dkpro-statistics-build/src/main/resources/dkpro-statistics/rules.xml
+++ b/dkpro-statistics-build/src/main/resources/dkpro-statistics/rules.xml
@@ -1,0 +1,38 @@
+<!--
+  Copyright 2026
+  Ubiquitous Knowledge Processing (UKP) Lab
+  Technische Universität Darmstadt
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<ruleset comparisonMethod="maven"
+         xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 http://mojo.codehaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
+  <ignoreVersions>
+    <!-- Pre-release suffixes - these are not "updates" -->
+    <ignoreVersion type="regex">(?i).*[-_\.]CR[0-9\.]*</ignoreVersion>
+    <ignoreVersion type="regex">(?i).*[-_\.]b[0-9\.]*</ignoreVersion>
+    <ignoreVersion type="regex">(?i).*[-_\.]M[0-9\.]*</ignoreVersion>
+    <ignoreVersion type="regex">(?i).*[-_\.]rc[0-9\.-]*</ignoreVersion>
+    <ignoreVersion type="regex">(?i).*[-_\.]alpha[0-9\.-]*</ignoreVersion>
+    <ignoreVersion type="regex">(?i).*[-_\.]beta[0-9\.-]*</ignoreVersion>
+    <ignoreVersion type="regex">(?i).*[-_\.]preview[0-9\.-]*</ignoreVersion>
+    <!-- Backwards-compat variants for legacy JDKs (e.g. byte-buddy 1.18.8-jdk5) -->
+    <ignoreVersion type="regex">(?i).*[-_\.]jdk[0-9]+</ignoreVersion>
+    <!-- e.g. commons-collections:commons-collections ... 3.2.1.redhat-7 -> 20040117.000000 -->
+    <ignoreVersion type="regex">\d{4,}.*</ignoreVersion>
+  </ignoreVersions>
+  <rules>
+    <!-- Per-artifact pins go here as needed -->
+  </rules>
+</ruleset>

--- a/pom.xml
+++ b/pom.xml
@@ -123,9 +123,9 @@
         <version>57.0.0</version>
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
+        <groupId>tools.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.22.0</version>
+        <version>3.2.0</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -74,8 +74,22 @@
   </licenses>
 
   <properties>
-    <maven.compiler.release>21</maven.compiler.release>    
+    <maven.compiler.release>21</maven.compiler.release>
   </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
+        <configuration>
+          <rulesUri>file:${maven.multiModuleProjectDirectory}/dkpro-statistics-build/src/main/resources/dkpro-statistics/rules.xml</rulesUri>
+          <allowAnyUpdates>false</allowAnyUpdates>
+          <allowMajorUpdates>false</allowMajorUpdates>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
   <modules>
     <module>dkpro-statistics-build</module>
@@ -101,7 +115,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.14.0</version>
+        <version>3.20.0</version>
       </dependency>
       <dependency>
         <groupId>org.ojalgo</groupId>
@@ -111,24 +125,24 @@
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
         <artifactId>jackson-databind</artifactId>
-        <version>2.18.2</version>
+        <version>2.22.0</version>
       </dependency>
       <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
-        <version>3.5.2</version>
+        <version>3.27.7</version>
       </dependency>
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>5.10.2</version>
+        <version>6.1.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-bom</artifactId>
-        <version>2.0.13</version>
+        <version>2.0.18</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -194,7 +208,7 @@
             <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-checkstyle-plugin</artifactId>
-              <version>3.4.0</version>
+              <version>3.6.0</version>
               <inherited>true</inherited>
               <dependencies>
                 <dependency>
@@ -205,7 +219,7 @@
                 <dependency>
                   <groupId>com.puppycrawl.tools</groupId>
                   <artifactId>checkstyle</artifactId>
-                  <version>10.17.0</version>
+                  <version>10.26.1</version>
                 </dependency>
               </dependencies>
               <configuration>


### PR DESCRIPTION
**What's in the PR**
- commons-lang3 3.14.0 -> 3.20.0
- jackson 2.18.2 -> 3.2.0
- assertj-core 3.5.2 -> 3.27.7
- junit-bom 5.10.2 -> 6.1.1
- slf4j-bom 2.0.13 -> 2.0.18
- maven-checkstyle-plugin 3.4.0 -> 3.6.0
- checkstyle 10.17.0 -> 10.26.1
- Add versions-maven-plugin configuration with rules.xml filter
- Add rules.xml to dkpro-statistics-build module for pre-release filtering

**How to test manually**
* No specific test procedure

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
