### PR TITLE
#35 - Krippendorff alpha reports 0.0 on full agreement

### DIFF
--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/DisagreementMeasure.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/DisagreementMeasure.java
@@ -1,8 +1,4 @@
 /*
- * Copyright 2014
- * Ubiquitous Knowledge Processing (UKP) Lab
- * Technische Universität Darmstadt
- * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -64,10 +60,29 @@ public abstract class DisagreementMeasure
         LOG.trace("Disagreement -- observed: {} -- expected: {}", D_O, D_E);
 
         if (D_O == D_E) {
+            // When observed and expected disagreement are equal, the chance-corrected agreement is
+            // zero -- except when both are zero, which is the case if all raters agreed on every
+            // unit. Such full agreement should yield 1.0 rather than 0.0, unless the study is empty
+            // and there is nothing to agree on. See issue #35.
+            if (D_O == 0.0) {
+                IAnnotationStudy study = getStudy();
+                return study != null && !study.isEmpty() ? 1.0 : 0.0;
+            }
+
             return 0.0;
         }
 
         return 1.0 - (D_O / D_E);
+    }
+
+    /**
+     * Returns the annotation study underlying this measure, or {@code null} if the measure does not
+     * operate on an {@link IAnnotationStudy} (e.g., purely text-based measures). This is used to
+     * tell an empty study apart from a study in which the raters fully agree.
+     */
+    protected IAnnotationStudy getStudy()
+    {
+        return null;
     }
 
     protected abstract double calculateObservedDisagreement();

--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/IAnnotationStudy.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/IAnnotationStudy.java
@@ -1,8 +1,4 @@
 /*
- * Copyright 2014
- * Ubiquitous Knowledge Processing (UKP) Lab
- * Technische Universität Darmstadt
- * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -77,4 +73,12 @@ public interface IAnnotationStudy
      * annotations coded by the raters.
      */
     int getUnitCount();
+
+    /**
+     * Returns true if, and only if, the study does not contain any annotation units.
+     */
+    default boolean isEmpty()
+    {
+        return getUnitCount() == 0;
+    }
 }

--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/coding/WeightedAgreement.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/coding/WeightedAgreement.java
@@ -1,8 +1,4 @@
 /*
- * Copyright 2014
- * Ubiquitous Knowledge Processing (UKP) Lab
- * Technische Universität Darmstadt
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -18,6 +14,7 @@
 package org.dkpro.statistics.agreement.coding;
 
 import org.dkpro.statistics.agreement.DisagreementMeasure;
+import org.dkpro.statistics.agreement.IAnnotationStudy;
 import org.dkpro.statistics.agreement.IWeightedAgreement;
 import org.dkpro.statistics.agreement.distance.IDistanceFunction;
 
@@ -66,6 +63,12 @@ public abstract class WeightedAgreement
             throw new NullPointerException("No distance function provided. " + "Use " + getClass()
                     + ".setDistanceFunction()!");
         }
+    }
+
+    @Override
+    protected IAnnotationStudy getStudy()
+    {
+        return study;
     }
 
 }

--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/unitizing/UnitizingAgreementMeasure.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/unitizing/UnitizingAgreementMeasure.java
@@ -1,8 +1,4 @@
 /*
- * Copyright 2014
- * Ubiquitous Knowledge Processing (UKP) Lab
- * Technische Universität Darmstadt
- * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -18,10 +14,11 @@
 package org.dkpro.statistics.agreement.unitizing;
 
 import org.dkpro.statistics.agreement.DisagreementMeasure;
+import org.dkpro.statistics.agreement.IAnnotationStudy;
 
 /**
  * Abstract base class of agreement measures for {@link IUnitizingAnnotationStudy}s.
- * 
+ *
  * @author Christian M. Meyer
  */
 public abstract class UnitizingAgreementMeasure
@@ -37,6 +34,12 @@ public abstract class UnitizingAgreementMeasure
     public UnitizingAgreementMeasure(final IUnitizingAnnotationStudy study)
     {
         this.study = study;
+    }
+
+    @Override
+    protected IAnnotationStudy getStudy()
+    {
+        return study;
     }
 
 }

--- a/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/coding/FullAgreementTest.java
+++ b/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/coding/FullAgreementTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.statistics.agreement.coding;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+
+import org.dkpro.statistics.agreement.distance.NominalDistanceFunction;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that full inter-rater agreement yields an agreement of 1.0 rather than 0.0. This is a
+ * regression test for issue #35, where {@link KrippendorffAlphaAgreement} reported an agreement of
+ * 0.0 when the observed and the expected disagreement were both zero (i.e., when all raters agreed
+ * on every unit).
+ */
+public class FullAgreementTest
+{
+    /**
+     * When every rater assigns the same single category to every unit while the study still defines
+     * more than one category (e.g., an unused category from the tagset), the observed and the
+     * expected disagreement are both zero. This is full agreement and must yield 1.0.
+     */
+    @Test
+    public void testFullAgreementSingleUsedCategory()
+    {
+        CodingAnnotationStudy study = new CodingAnnotationStudy(2);
+        // Declare a second category that is never actually used by the raters.
+        study.addCategory("A");
+        study.addCategory("B");
+        study.addItem("A", "A");
+        study.addItem("A", "A");
+        study.addItem("A", "A");
+
+        KrippendorffAlphaAgreement alpha = new KrippendorffAlphaAgreement(study,
+                new NominalDistanceFunction());
+        assertThat(alpha.calculateObservedDisagreement()).isCloseTo(0.0, offset(0.001));
+        assertThat(alpha.calculateExpectedDisagreement()).isCloseTo(0.0, offset(0.001));
+        assertThat(alpha.calculateAgreement()).isCloseTo(1.0, offset(0.001));
+    }
+
+    /**
+     * When the raters fully agree but use more than one category, the expected disagreement is
+     * greater than zero. This case already yielded 1.0 before the fix and must keep doing so.
+     */
+    @Test
+    public void testFullAgreementMultipleUsedCategories()
+    {
+        CodingAnnotationStudy study = new CodingAnnotationStudy(2);
+        study.addItem("A", "A");
+        study.addItem("B", "B");
+        study.addItem("A", "A");
+        study.addItem("B", "B");
+
+        KrippendorffAlphaAgreement alpha = new KrippendorffAlphaAgreement(study,
+                new NominalDistanceFunction());
+        assertThat(alpha.calculateObservedDisagreement()).isCloseTo(0.0, offset(0.001));
+        assertThat(alpha.calculateExpectedDisagreement()).isGreaterThan(0.0);
+        assertThat(alpha.calculateAgreement()).isCloseTo(1.0, offset(0.001));
+    }
+}


### PR DESCRIPTION
**What's in the PR**
- Fix Krippendorff's alpha reporting 0.0 on full inter-rater agreement
- Add isEmpty() default method to IAnnotationStudy to distinguish empty studies from full agreement
- Return 1.0 (not 0.0) when D_O == D_E == 0 for non-empty studies in DisagreementMeasure
- Override getStudy() in WeightedAgreement and UnitizingAgreementMeasure to expose annotation study
- Add regression test (FullAgreementTest) covering single-category and multi-category full agreement cases

**How to test manually**
* See issue description

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
