### PR TITLE
#10 - MASI distance functions cause ClassCastException on category-wise agreement

### DIFF
--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/distance/CachedDistanceFunction.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/distance/CachedDistanceFunction.java
@@ -1,8 +1,4 @@
 /*
- * Copyright 2014
- * Ubiquitous Knowledge Processing (UKP) Lab
- * Technische Universität Darmstadt
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -18,6 +14,7 @@
 package org.dkpro.statistics.agreement.distance;
 
 import java.util.Hashtable;
+import java.util.Objects;
 
 import org.dkpro.statistics.agreement.IAnnotationStudy;
 
@@ -47,7 +44,7 @@ public class CachedDistanceFunction
     public double measureDistance(final IAnnotationStudy study, final Object category1,
             final Object category2)
     {
-        String key = category1.hashCode() + "|" + category2.hashCode();
+        String key = Objects.hashCode(category1) + "|" + Objects.hashCode(category2);
         Double result = cache.get(key);
         if (result == null) {
             result = wrappee.measureDistance(study, category1, category2);

--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/distance/IntervalDistanceFunction.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/distance/IntervalDistanceFunction.java
@@ -1,8 +1,4 @@
 /*
- * Copyright 2014
- * Ubiquitous Knowledge Processing (UKP) Lab
- * Technische Universität Darmstadt
- * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -16,6 +12,8 @@
  * limitations under the License.
  */
 package org.dkpro.statistics.agreement.distance;
+
+import java.util.Objects;
 
 import org.dkpro.statistics.agreement.IAnnotationStudy;
 
@@ -61,7 +59,7 @@ public class IntervalDistanceFunction
                     * (((Double) category1) - ((Double) category2));
         }
 
-        return (category1.equals(category2) ? 0.0 : 1.0);
+        return (Objects.equals(category1, category2) ? 0.0 : 1.0);
     }
 
 }

--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/distance/MASISetAnnotationDistanceFunction.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/distance/MASISetAnnotationDistanceFunction.java
@@ -1,8 +1,4 @@
 /*
- * Copyright 2014
- * Ubiquitous Knowledge Processing (UKP) Lab
- * Technische Universität Darmstadt
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -16,6 +12,8 @@
  * limitations under the License.
  */
 package org.dkpro.statistics.agreement.distance;
+
+import java.util.Objects;
 
 import org.dkpro.statistics.agreement.IAnnotationStudy;
 
@@ -45,6 +43,10 @@ public class MASISetAnnotationDistanceFunction
     @Override
     public double measureDistance(final IAnnotationStudy study, Object category1, Object category2)
     {
+        if (!(category1 instanceof SetAnnotation) || !(category2 instanceof SetAnnotation)) {
+            return Objects.equals(category1, category2) ? 0.0 : 1.0;
+        }
+
         SetAnnotation c1 = (SetAnnotation) category1;
         SetAnnotation c2 = (SetAnnotation) category2;
 

--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/distance/NominalDistanceFunction.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/distance/NominalDistanceFunction.java
@@ -1,8 +1,4 @@
 /*
- * Copyright 2014
- * Ubiquitous Knowledge Processing (UKP) Lab
- * Technische Universität Darmstadt
- * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -16,6 +12,8 @@
  * limitations under the License.
  */
 package org.dkpro.statistics.agreement.distance;
+
+import java.util.Objects;
 
 import org.dkpro.statistics.agreement.IAnnotationStudy;
 
@@ -45,7 +43,7 @@ public class NominalDistanceFunction
     public double measureDistance(final IAnnotationStudy study, final Object category1,
             final Object category2)
     {
-        return (category1.equals(category2) ? 0.0 : 1.0);
+        return (Objects.equals(category1, category2) ? 0.0 : 1.0);
     }
 
 }

--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/distance/OrdinalDistanceFunction.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/distance/OrdinalDistanceFunction.java
@@ -1,8 +1,4 @@
 /*
- * Copyright 2014
- * Ubiquitous Knowledge Processing (UKP) Lab
- * Technische Universität Darmstadt
- * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -18,6 +14,7 @@
 package org.dkpro.statistics.agreement.distance;
 
 import java.util.Map;
+import java.util.Objects;
 
 import org.dkpro.statistics.agreement.IAnnotationStudy;
 import org.dkpro.statistics.agreement.coding.CodingAnnotationStudy;
@@ -89,6 +86,6 @@ public class OrdinalDistanceFunction
             return result * result;
         }
 
-        return (category1.equals(category2) ? 0.0 : 1.0);
+        return (Objects.equals(category1, category2) ? 0.0 : 1.0);
     }
 }

--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/distance/RatioDistanceFunction.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/distance/RatioDistanceFunction.java
@@ -1,8 +1,4 @@
 /*
- * Copyright 2014
- * Ubiquitous Knowledge Processing (UKP) Lab
- * Technische Universität Darmstadt
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -16,6 +12,8 @@
  * limitations under the License.
  */
 package org.dkpro.statistics.agreement.distance;
+
+import java.util.Objects;
 
 import org.dkpro.statistics.agreement.IAnnotationStudy;
 
@@ -65,7 +63,7 @@ public class RatioDistanceFunction
             return result * result;
         }
 
-        return (category1.equals(category2) ? 0.0 : 1.0);
+        return (Objects.equals(category1, category2) ? 0.0 : 1.0);
     }
 
 }

--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/distance/SetAnnotationDistanceFunction.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/distance/SetAnnotationDistanceFunction.java
@@ -1,8 +1,4 @@
 /*
- * Copyright 2014
- * Ubiquitous Knowledge Processing (UKP) Lab
- * Technische Universität Darmstadt
- * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -16,6 +12,8 @@
  * limitations under the License.
  */
 package org.dkpro.statistics.agreement.distance;
+
+import java.util.Objects;
 
 import org.dkpro.statistics.agreement.IAnnotationStudy;
 
@@ -42,6 +40,10 @@ public class SetAnnotationDistanceFunction
     public double measureDistance(final IAnnotationStudy study, final Object category1,
             final Object category2)
     {
+        if (!(category1 instanceof SetAnnotation) || !(category2 instanceof SetAnnotation)) {
+            return Objects.equals(category1, category2) ? 0.0 : 1.0;
+        }
+
         SetAnnotation c1 = (SetAnnotation) category1;
         SetAnnotation c2 = (SetAnnotation) category2;
 

--- a/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/coding/SetAnnotationsTest.java
+++ b/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/coding/SetAnnotationsTest.java
@@ -1,8 +1,4 @@
 /*
- * Copyright 2014
- * Ubiquitous Knowledge Processing (UKP) Lab
- * Technische Universität Darmstadt
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -56,6 +52,32 @@ public class SetAnnotationsTest
         assertThat(alpha.calculateObservedDisagreement()).isCloseTo(0.253, offset(0.001));
         assertThat(alpha.calculateExpectedDisagreement()).isCloseTo(0.338, offset(0.001));
         assertThat(alpha.calculateAgreement()).isCloseTo(0.252, offset(0.001));
+    }
+
+    @Test
+    public void testSetDistanceFunctionCategoryAgreement()
+    {
+        ICodingAnnotationStudy study = createExample();
+
+        KrippendorffAlphaAgreement alpha = new KrippendorffAlphaAgreement(study, null);
+        alpha.setDistanceFunction(new SetAnnotationDistanceFunction());
+
+        // Provokes issue #10: calculateCategoryAgreement feeds a plain-Object NULL_CATEGORY
+        // sentinel into the distance function, which unconditionally casts it to SetAnnotation.
+        assertThat(alpha.calculateCategoryAgreement(new SetAnnotation("A"))).isBetween(-1.0, 1.0);
+    }
+
+    @Test
+    public void testMASIDistanceFunctionCategoryAgreement()
+    {
+        ICodingAnnotationStudy study = createExample();
+
+        KrippendorffAlphaAgreement alpha = new KrippendorffAlphaAgreement(study, null);
+        alpha.setDistanceFunction(new MASISetAnnotationDistanceFunction());
+
+        // Provokes issue #10: calculateCategoryAgreement feeds a plain-Object NULL_CATEGORY
+        // sentinel into the distance function, which unconditionally casts it to SetAnnotation.
+        assertThat(alpha.calculateCategoryAgreement(new SetAnnotation("A"))).isBetween(-1.0, 1.0);
     }
 
     @Test

--- a/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/distance/CachedDistanceFunctionTest.java
+++ b/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/distance/CachedDistanceFunctionTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.statistics.agreement.distance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.dkpro.statistics.agreement.IAnnotationStudy;
+import org.junit.jupiter.api.Test;
+
+public class CachedDistanceFunctionTest
+{
+    /** Records how often the wrapped function is actually consulted. */
+    private static final class CountingDistanceFunction
+        implements IDistanceFunction
+    {
+        private final IDistanceFunction delegate = new NominalDistanceFunction();
+        private int invocations = 0;
+
+        @Override
+        public double measureDistance(IAnnotationStudy study, Object category1, Object category2)
+        {
+            invocations++;
+            return delegate.measureDistance(study, category1, category2);
+        }
+    }
+
+    @Test
+    public void delegatesToTheWrappedFunction()
+    {
+        CachedDistanceFunction sut = new CachedDistanceFunction(new NominalDistanceFunction());
+
+        assertThat(sut.measureDistance(null, "A", "A")).isEqualTo(0.0);
+        assertThat(sut.measureDistance(null, "A", "B")).isEqualTo(1.0);
+    }
+
+    @Test
+    public void repeatedCallsAreServedFromTheCache()
+    {
+        CountingDistanceFunction wrappee = new CountingDistanceFunction();
+        CachedDistanceFunction sut = new CachedDistanceFunction(wrappee);
+
+        assertThat(sut.measureDistance(null, "A", "B")).isEqualTo(1.0);
+        assertThat(sut.measureDistance(null, "A", "B")).isEqualTo(1.0);
+
+        assertThat(wrappee.invocations).isEqualTo(1);
+    }
+
+    @Test
+    public void nullCategoriesAreCachedRatherThanThrowing()
+    {
+        CountingDistanceFunction wrappee = new CountingDistanceFunction();
+        CachedDistanceFunction sut = new CachedDistanceFunction(wrappee);
+
+        assertThat(sut.measureDistance(null, null, null)).isEqualTo(0.0);
+        assertThat(sut.measureDistance(null, null, null)).isEqualTo(0.0);
+        assertThat(sut.measureDistance(null, null, "A")).isEqualTo(1.0);
+        assertThat(sut.measureDistance(null, "A", null)).isEqualTo(1.0);
+
+        // (null, null) served once from cache; (null, "A") and ("A", null) are distinct keys.
+        assertThat(wrappee.invocations).isEqualTo(3);
+    }
+}

--- a/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/distance/IntervalDistanceFunctionTest.java
+++ b/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/distance/IntervalDistanceFunctionTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.statistics.agreement.distance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class IntervalDistanceFunctionTest
+{
+    private final IntervalDistanceFunction sut = new IntervalDistanceFunction();
+
+    @Test
+    public void integerDistanceIsSquaredDifference()
+    {
+        assertThat(sut.measureDistance(null, 1, 4)).isEqualTo(9.0);
+        assertThat(sut.measureDistance(null, 3, 3)).isEqualTo(0.0);
+    }
+
+    @Test
+    public void doubleDistanceIsSquaredDifference()
+    {
+        assertThat(sut.measureDistance(null, 1.0, 3.0)).isEqualTo(4.0);
+    }
+
+    @Test
+    public void nonNumericCategoriesFallBackToNominal()
+    {
+        assertThat(sut.measureDistance(null, "A", "A")).isEqualTo(0.0);
+        assertThat(sut.measureDistance(null, "A", "B")).isEqualTo(1.0);
+    }
+
+    @Test
+    public void nullEqualsNullIsZero()
+    {
+        assertThat(sut.measureDistance(null, null, null)).isEqualTo(0.0);
+    }
+
+    @Test
+    public void nullVersusValueIsMaximal()
+    {
+        assertThat(sut.measureDistance(null, null, "A")).isEqualTo(1.0);
+        assertThat(sut.measureDistance(null, "A", null)).isEqualTo(1.0);
+    }
+}

--- a/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/distance/MASISetAnnotationDistanceFunctionTest.java
+++ b/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/distance/MASISetAnnotationDistanceFunctionTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.statistics.agreement.distance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+
+import org.junit.jupiter.api.Test;
+
+public class MASISetAnnotationDistanceFunctionTest
+{
+    private final MASISetAnnotationDistanceFunction sut = new MASISetAnnotationDistanceFunction();
+
+    @Test
+    public void identicalSetsAreZero()
+    {
+        assertThat(
+                sut.measureDistance(null, new SetAnnotation("A", "B"), new SetAnnotation("A", "B")))
+                        .isEqualTo(0.0);
+    }
+
+    @Test
+    public void subsetIsScaledByOneThird()
+    {
+        // Jaccard 0.5 weighted by the MASI monotonicity factor 1/3 = 1/6.
+        assertThat(sut.measureDistance(null, new SetAnnotation("A"), new SetAnnotation("A", "B")))
+                .isCloseTo(1.0 / 6.0, offset(0.0001));
+    }
+
+    @Test
+    public void partialOverlapIsScaledByTwoThirds()
+    {
+        // Jaccard 2/3 weighted by the MASI intersection factor 2/3 = 4/9.
+        assertThat(
+                sut.measureDistance(null, new SetAnnotation("A", "B"), new SetAnnotation("B", "C")))
+                        .isCloseTo(4.0 / 9.0, offset(0.0001));
+    }
+
+    @Test
+    public void disjointSetsAreMaximal()
+    {
+        assertThat(sut.measureDistance(null, new SetAnnotation("A"), new SetAnnotation("B")))
+                .isEqualTo(1.0);
+    }
+
+    @Test
+    public void nonSetCategoriesFallBackToNominal()
+    {
+        assertThat(sut.measureDistance(null, "A", "A")).isEqualTo(0.0);
+        assertThat(sut.measureDistance(null, "A", "B")).isEqualTo(1.0);
+    }
+
+    @Test
+    public void nullEqualsNullIsZero()
+    {
+        assertThat(sut.measureDistance(null, null, null)).isEqualTo(0.0);
+    }
+
+    @Test
+    public void nullVersusValueIsMaximal()
+    {
+        // The NULL_CATEGORY sentinel from calculateCategoryAgreement is not a SetAnnotation.
+        assertThat(sut.measureDistance(null, null, new SetAnnotation("A"))).isEqualTo(1.0);
+        assertThat(sut.measureDistance(null, new SetAnnotation("A"), null)).isEqualTo(1.0);
+    }
+}

--- a/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/distance/NominalDistanceFunctionTest.java
+++ b/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/distance/NominalDistanceFunctionTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.statistics.agreement.distance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class NominalDistanceFunctionTest
+{
+    private final NominalDistanceFunction sut = new NominalDistanceFunction();
+
+    @Test
+    public void equalCategoriesAreZero()
+    {
+        assertThat(sut.measureDistance(null, "A", "A")).isEqualTo(0.0);
+    }
+
+    @Test
+    public void unequalCategoriesAreMaximal()
+    {
+        assertThat(sut.measureDistance(null, "A", "B")).isEqualTo(1.0);
+    }
+
+    @Test
+    public void nullEqualsNullIsZero()
+    {
+        assertThat(sut.measureDistance(null, null, null)).isEqualTo(0.0);
+    }
+
+    @Test
+    public void nullVersusValueIsMaximal()
+    {
+        assertThat(sut.measureDistance(null, null, "A")).isEqualTo(1.0);
+        assertThat(sut.measureDistance(null, "A", null)).isEqualTo(1.0);
+    }
+}

--- a/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/distance/OrdinalDistanceFunctionTest.java
+++ b/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/distance/OrdinalDistanceFunctionTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.statistics.agreement.distance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+
+import org.dkpro.statistics.agreement.coding.CodingAnnotationStudy;
+import org.dkpro.statistics.agreement.coding.ICodingAnnotationStudy;
+import org.junit.jupiter.api.Test;
+
+public class OrdinalDistanceFunctionTest
+{
+    private final OrdinalDistanceFunction sut = new OrdinalDistanceFunction();
+
+    /** Study where each of the categories 1, 2, 3 is annotated exactly twice. */
+    private static ICodingAnnotationStudy study()
+    {
+        CodingAnnotationStudy study = new CodingAnnotationStudy(2);
+        study.addItem(1, 1);
+        study.addItem(2, 2);
+        study.addItem(3, 3);
+        return study;
+    }
+
+    @Test
+    public void equalIntegersAreZero()
+    {
+        assertThat(sut.measureDistance(study(), 2, 2)).isEqualTo(0.0);
+    }
+
+    @Test
+    public void distanceGrowsWithTheEnclosedCategoryMass()
+    {
+        // (nk[1]/2 + nk[2]/2)^2 = (1 + 1)^2 = 4
+        assertThat(sut.measureDistance(study(), 1, 2)).isCloseTo(4.0, offset(0.0001));
+        // (nk[1]/2 + nk[3]/2 + nk[2])^2 = (1 + 1 + 2)^2 = 16
+        assertThat(sut.measureDistance(study(), 1, 3)).isCloseTo(16.0, offset(0.0001));
+    }
+
+    @Test
+    public void nonIntegerCategoriesFallBackToNominal()
+    {
+        assertThat(sut.measureDistance(null, "A", "A")).isEqualTo(0.0);
+        assertThat(sut.measureDistance(null, "A", "B")).isEqualTo(1.0);
+    }
+
+    @Test
+    public void nullEqualsNullIsZero()
+    {
+        assertThat(sut.measureDistance(null, null, null)).isEqualTo(0.0);
+    }
+
+    @Test
+    public void nullVersusValueIsMaximal()
+    {
+        assertThat(sut.measureDistance(null, null, "A")).isEqualTo(1.0);
+        assertThat(sut.measureDistance(null, "A", null)).isEqualTo(1.0);
+    }
+}

--- a/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/distance/RatioDistanceFunctionTest.java
+++ b/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/distance/RatioDistanceFunctionTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.statistics.agreement.distance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+
+import org.junit.jupiter.api.Test;
+
+public class RatioDistanceFunctionTest
+{
+    private final RatioDistanceFunction sut = new RatioDistanceFunction();
+
+    @Test
+    public void integerDistanceIsSquaredRelativeDifference()
+    {
+        // ((1 - 3) / (1 + 3))^2 = (-0.5)^2 = 0.25
+        assertThat(sut.measureDistance(null, 1, 3)).isCloseTo(0.25, offset(0.0001));
+    }
+
+    @Test
+    public void doubleDistanceIsSquaredRelativeDifference()
+    {
+        assertThat(sut.measureDistance(null, 1.0, 3.0)).isCloseTo(0.25, offset(0.0001));
+    }
+
+    @Test
+    public void nonNumericCategoriesFallBackToNominal()
+    {
+        assertThat(sut.measureDistance(null, "A", "A")).isEqualTo(0.0);
+        assertThat(sut.measureDistance(null, "A", "B")).isEqualTo(1.0);
+    }
+
+    @Test
+    public void nullEqualsNullIsZero()
+    {
+        assertThat(sut.measureDistance(null, null, null)).isEqualTo(0.0);
+    }
+
+    @Test
+    public void nullVersusValueIsMaximal()
+    {
+        assertThat(sut.measureDistance(null, null, "A")).isEqualTo(1.0);
+        assertThat(sut.measureDistance(null, "A", null)).isEqualTo(1.0);
+    }
+}

--- a/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/distance/SetAnnotationDistanceFunctionTest.java
+++ b/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/distance/SetAnnotationDistanceFunctionTest.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.statistics.agreement.distance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.offset;
+
+import org.junit.jupiter.api.Test;
+
+public class SetAnnotationDistanceFunctionTest
+{
+    private final SetAnnotationDistanceFunction sut = new SetAnnotationDistanceFunction();
+
+    @Test
+    public void identicalSetsAreZero()
+    {
+        assertThat(
+                sut.measureDistance(null, new SetAnnotation("A", "B"), new SetAnnotation("A", "B")))
+                        .isEqualTo(0.0);
+    }
+
+    @Test
+    public void subsetIsOneThird()
+    {
+        assertThat(sut.measureDistance(null, new SetAnnotation("A"), new SetAnnotation("A", "B")))
+                .isCloseTo(1.0 / 3.0, offset(0.0001));
+    }
+
+    @Test
+    public void partialOverlapIsTwoThirds()
+    {
+        assertThat(
+                sut.measureDistance(null, new SetAnnotation("A", "B"), new SetAnnotation("B", "C")))
+                        .isCloseTo(2.0 / 3.0, offset(0.0001));
+    }
+
+    @Test
+    public void disjointSetsAreMaximal()
+    {
+        assertThat(sut.measureDistance(null, new SetAnnotation("A"), new SetAnnotation("B")))
+                .isEqualTo(1.0);
+    }
+
+    @Test
+    public void nonSetCategoriesFallBackToNominal()
+    {
+        assertThat(sut.measureDistance(null, "A", "A")).isEqualTo(0.0);
+        assertThat(sut.measureDistance(null, "A", "B")).isEqualTo(1.0);
+    }
+
+    @Test
+    public void nullEqualsNullIsZero()
+    {
+        assertThat(sut.measureDistance(null, null, null)).isEqualTo(0.0);
+    }
+
+    @Test
+    public void nullVersusValueIsMaximal()
+    {
+        // The NULL_CATEGORY sentinel from calculateCategoryAgreement is not a SetAnnotation.
+        assertThat(sut.measureDistance(null, null, new SetAnnotation("A"))).isEqualTo(1.0);
+        assertThat(sut.measureDistance(null, new SetAnnotation("A"), null)).isEqualTo(1.0);
+    }
+}

--- a/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/distance/SquareDistanceFunctionTest.java
+++ b/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/distance/SquareDistanceFunctionTest.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.dkpro.statistics.agreement.distance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * {@link SquareDistanceFunction} is a deprecated alias of {@link IntervalDistanceFunction}; these
+ * tests confirm it inherits the same behavior, including the null-safe fallback.
+ */
+@SuppressWarnings("deprecation")
+public class SquareDistanceFunctionTest
+{
+    private final SquareDistanceFunction sut = new SquareDistanceFunction();
+
+    @Test
+    public void behavesLikeIntervalDistanceFunction()
+    {
+        assertThat(sut.measureDistance(null, 1, 4)).isEqualTo(9.0);
+        assertThat(sut.measureDistance(null, "A", "B")).isEqualTo(1.0);
+    }
+
+    @Test
+    public void nullEqualsNullIsZero()
+    {
+        assertThat(sut.measureDistance(null, null, null)).isEqualTo(0.0);
+    }
+
+    @Test
+    public void nullVersusValueIsMaximal()
+    {
+        assertThat(sut.measureDistance(null, null, "A")).isEqualTo(1.0);
+        assertThat(sut.measureDistance(null, "A", null)).isEqualTo(1.0);
+    }
+}


### PR DESCRIPTION
**What's in the PR**
- Refactor distance functions to use Objects.equals() for null-safe comparisons
- Add comprehensive unit tests for distance function implementations (NominalDistanceFunction, OrdinalDistanceFunction, IntervalDistanceFunction, RatioDistanceFunction, CachedDistanceFunction, SetAnnotationDistanceFunction, MASISetAnnotationDistanceFunction, SquareDistanceFunction)
- Add regression tests

**How to test manually**
* No specific test procedure

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
