### PR TITLE
#50 - Inter-annotator agreement score is too high when different category labels are wrongly treated as identical

### DIFF
--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/distance/CachedDistanceFunction.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/distance/CachedDistanceFunction.java
@@ -13,8 +13,10 @@
  */
 package org.dkpro.statistics.agreement.distance;
 
+import java.util.Arrays;
 import java.util.Hashtable;
-import java.util.Objects;
+import java.util.List;
+import java.util.Map;
 
 import org.dkpro.statistics.agreement.IAnnotationStudy;
 
@@ -22,29 +24,38 @@ import org.dkpro.statistics.agreement.IAnnotationStudy;
  * Wrapper class for arbitrary distance functions that caches the distance scores between two
  * categories in a hash table. This is useful, if the calculation of a distance value is
  * computationally complex, for instance, for set-valued categories as assumed by the
- * {@link SetAnnotationDistanceFunction}.
- * 
+ * {@link SetAnnotationDistanceFunction}.<br>
+ * <br>
+ * <b>Important:</b> the cache is keyed solely on the pair of categories; the annotation study is
+ * <i>not</i> part of the key. A single instance must therefore not be reused across different
+ * studies when the wrapped distance function is study-dependent (i.e., returns different distances
+ * for the same category pair depending on the study, as {@link OrdinalDistanceFunction} does).
+ * Doing so would serve the first study's cached distances for subsequent studies and silently
+ * produce wrong agreement scores. Create a fresh instance per study, or only cache
+ * study-independent distance functions (e.g., {@link NominalDistanceFunction},
+ * {@link SetAnnotationDistanceFunction}).
+ *
  * @see IDistanceFunction
  * @author Christian M. Meyer
  */
 public class CachedDistanceFunction
     implements IDistanceFunction
 {
-    protected Hashtable<String, Double> cache;
+    protected Map<List<Object>, Double> cache;
     protected IDistanceFunction wrappee;
 
     /** Instantiates the wrapper for the given distance function. */
     public CachedDistanceFunction(final IDistanceFunction wrappee)
     {
         this.wrappee = wrappee;
-        cache = new Hashtable<String, Double>();
+        cache = new Hashtable<List<Object>, Double>();
     }
 
     @Override
     public double measureDistance(final IAnnotationStudy study, final Object category1,
             final Object category2)
     {
-        String key = Objects.hashCode(category1) + "|" + Objects.hashCode(category2);
+        List<Object> key = Arrays.asList(category1, category2);
         Double result = cache.get(key);
         if (result == null) {
             result = wrappee.measureDistance(study, category1, category2);

--- a/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/distance/CachedDistanceFunctionTest.java
+++ b/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/distance/CachedDistanceFunctionTest.java
@@ -57,6 +57,18 @@ public class CachedDistanceFunctionTest
     }
 
     @Test
+    public void distinctCategoriesWithEqualHashCodesDoNotCollide()
+    {
+        CachedDistanceFunction sut = new CachedDistanceFunction(new NominalDistanceFunction());
+
+        // "Aa" and "BB" are distinct but share the same String hashCode (2112).
+        assertThat("Aa".hashCode()).isEqualTo("BB".hashCode());
+
+        assertThat(sut.measureDistance(null, "Aa", "Aa")).isEqualTo(0.0);
+        assertThat(sut.measureDistance(null, "Aa", "BB")).isEqualTo(1.0);
+    }
+
+    @Test
     public void nullCategoriesAreCachedRatherThanThrowing()
     {
         CountingDistanceFunction wrappee = new CountingDistanceFunction();


### PR DESCRIPTION
**What's in the PR**
- Fix cache key collision in CachedDistanceFunction by keying on actual category objects instead of their hash codes
- Add regression test for hash-collision scenario in CachedDistanceFunction cache

**How to test manually**
* See issue description

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
