### PR TITLE
#52 - Scores can be wildly wrong when category values are large numbers

### DIFF
--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/distance/IntervalDistanceFunction.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/distance/IntervalDistanceFunction.java
@@ -50,8 +50,8 @@ public class IntervalDistanceFunction
             final Object category2)
     {
         if (category1 instanceof Integer && category2 instanceof Integer) {
-            return (((Integer) category1) - ((Integer) category2))
-                    * (((Integer) category1) - ((Integer) category2));
+            double diff = ((Integer) category1).doubleValue() - ((Integer) category2).doubleValue();
+            return diff * diff;
         }
 
         if (category1 instanceof Double && category2 instanceof Double) {

--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/distance/RatioDistanceFunction.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/distance/RatioDistanceFunction.java
@@ -49,11 +49,13 @@ public class RatioDistanceFunction
     public double measureDistance(final IAnnotationStudy study, final Object category1,
             final Object category2)
     {
-        if (category1 instanceof Integer && category2 instanceof Integer
-                && (((Integer) category1) + ((Integer) category2) > 0.0)) {
-            double result = (((Integer) category1) - ((Integer) category2))
-                    / (double) (((Integer) category1) + ((Integer) category2));
-            return result * result;
+        if (category1 instanceof Integer && category2 instanceof Integer) {
+            double c1 = ((Integer) category1).doubleValue();
+            double c2 = ((Integer) category2).doubleValue();
+            if (c1 + c2 > 0.0) {
+                double result = (c1 - c2) / (c1 + c2);
+                return result * result;
+            }
         }
 
         if (category1 instanceof Double && category2 instanceof Double

--- a/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/distance/IntervalDistanceFunctionTest.java
+++ b/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/distance/IntervalDistanceFunctionTest.java
@@ -29,6 +29,14 @@ public class IntervalDistanceFunctionTest
     }
 
     @Test
+    public void largeIntegerDistanceDoesNotOverflow()
+    {
+        // 100000^2 == 1.0E10 exceeds Integer.MAX_VALUE; computing the squared difference
+        // in int arithmetic would silently overflow to 1410065408.
+        assertThat(sut.measureDistance(null, 100000, 0)).isEqualTo(1.0E10);
+    }
+
+    @Test
     public void doubleDistanceIsSquaredDifference()
     {
         assertThat(sut.measureDistance(null, 1.0, 3.0)).isEqualTo(4.0);

--- a/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/distance/RatioDistanceFunctionTest.java
+++ b/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/distance/RatioDistanceFunctionTest.java
@@ -30,6 +30,16 @@ public class RatioDistanceFunctionTest
     }
 
     @Test
+    public void largeIntegerDistanceDoesNotOverflow()
+    {
+        // Integer.MAX_VALUE + 1 overflows int arithmetic to a negative sum, making the
+        // positivity guard fail and the result fall back to the nominal 1.0. The true
+        // ((MAX - 1) / (MAX + 1))^2 is very close to 1.0 but not exactly 1.0.
+        assertThat(sut.measureDistance(null, Integer.MAX_VALUE, 1)).isCloseTo(1.0, offset(0.0001))
+                .isLessThan(1.0);
+    }
+
+    @Test
     public void doubleDistanceIsSquaredRelativeDifference()
     {
         assertThat(sut.measureDistance(null, 1.0, 3.0)).isCloseTo(0.25, offset(0.0001));


### PR DESCRIPTION
**What's in the PR**
- Fix integer overflow in IntervalDistanceFunction when computing squared differences with large integer values
- Add regression test for large integer overflow case in interval distance calculation

**How to test manually**
* See issue description

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
