### PR TITLE
#58 - Alpha_U reports full agreement (1.0) for studies containing only zero-length units

### DIFF
--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/DisagreementMeasure.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/DisagreementMeasure.java
@@ -62,11 +62,11 @@ public abstract class DisagreementMeasure
         if (D_O == D_E) {
             // When observed and expected disagreement are equal, the chance-corrected agreement is
             // zero -- except when both are zero, which is the case if all raters agreed on every
-            // unit. Such full agreement should yield 1.0 rather than 0.0, unless the study is empty
-            // and there is nothing to agree on. See issue #35.
+            // unit. Such full agreement should yield 1.0 rather than 0.0, unless the study carries
+            // no information from which agreement could be inferred and there is nothing to agree
+            // on. See issue #35.
             if (D_O == 0.0) {
-                IAnnotationStudy study = getStudy();
-                return study != null && !study.isEmpty() ? 1.0 : 0.0;
+                return studyCarriesInformation() ? 1.0 : 0.0;
             }
 
             return 0.0;
@@ -83,6 +83,20 @@ public abstract class DisagreementMeasure
     protected IAnnotationStudy getStudy()
     {
         return null;
+    }
+
+    /**
+     * Tells whether the underlying study carries any information from which the measure can infer
+     * agreement. {@link #calculateAgreement()} uses this to tell full agreement (yielding 1.0)
+     * apart from a study the measure cannot draw any conclusion from (yielding 0.0), such as an
+     * empty study. Subclasses should refine this check if there are further study configurations
+     * that are invisible to the measure, e.g. length-weighted unitizing measures cannot observe
+     * zero-length units.
+     */
+    protected boolean studyCarriesInformation()
+    {
+        IAnnotationStudy study = getStudy();
+        return study != null && !study.isEmpty();
     }
 
     protected abstract double calculateObservedDisagreement();

--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/unitizing/KrippendorffAlphaUnitizingAgreement.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/unitizing/KrippendorffAlphaUnitizingAgreement.java
@@ -188,10 +188,6 @@ public class KrippendorffAlphaUnitizingAgreement
                     offset = pos;
                 }
 
-                if (length < 0) {
-                    var x = 0;
-                }
-
                 pos = offset + length;
             }
         }

--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/unitizing/UnitizingAgreementMeasure.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/unitizing/UnitizingAgreementMeasure.java
@@ -42,4 +42,25 @@ public abstract class UnitizingAgreementMeasure
         return study;
     }
 
+    /**
+     * Unitizing measures weight all (dis)agreement by unit length. Zero-length units carry no mass,
+     * so a study consisting solely of such units is degenerate: both the observed and the expected
+     * disagreement are necessarily zero regardless of the positions and categories of the units.
+     * Such a study must not be mistaken for full agreement.
+     */
+    @Override
+    protected boolean studyCarriesInformation()
+    {
+        if (!super.studyCarriesInformation()) {
+            return false;
+        }
+
+        for (IUnitizingAnnotationUnit unit : study.getUnits()) {
+            if (unit.getLength() > 0) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/unitizing/UnitizingAgreementTest.java
+++ b/dkpro-statistics-agreement/src/test/java/org/dkpro/statistics/agreement/unitizing/UnitizingAgreementTest.java
@@ -70,6 +70,62 @@ public class UnitizingAgreementTest
         assertThat(alpha.calculateAgreement()).isNaN();
     }
 
+    /**
+     * Two raters annotate the same position with a zero-length unit, but assign different
+     * categories. Alpha_U weights all (dis)agreement by unit length, so the measure cannot see the
+     * units (zero mass): the study is degenerate and must not yield 1.0 even though the observed
+     * and the expected disagreement are both zero. See issue #35.
+     */
+    @Test
+    public void testOnlyZeroLengthUnitsWithDifferingCategories()
+    {
+        var study = new UnitizingAnnotationStudy(2, 15);
+        study.addUnit(0, 0, 0, "A");
+        study.addUnit(0, 0, 1, "B");
+
+        var alpha = new KrippendorffAlphaUnitizingAgreement(study);
+        assertThat(alpha.calculateObservedDisagreement()).isCloseTo(0.0, offset(0.001));
+        assertThat(alpha.calculateExpectedDisagreement()).isCloseTo(0.0, offset(0.001));
+        assertThat(alpha.calculateAgreement()).isCloseTo(0.0, offset(0.001));
+    }
+
+    /**
+     * Two raters annotate the same position with a zero-length unit of the same category. Although
+     * this looks like agreement, the units carry no mass and the study is just as degenerate as in
+     * the differing-categories case -- the measure cannot tell the two situations apart.
+     */
+    @Test
+    public void testOnlyZeroLengthUnitsWithSameCategory()
+    {
+        var study = new UnitizingAnnotationStudy(2, 15);
+        study.addUnit(0, 0, 0, "A");
+        study.addUnit(0, 0, 1, "A");
+
+        var alpha = new KrippendorffAlphaUnitizingAgreement(study);
+        assertThat(alpha.calculateObservedDisagreement()).isCloseTo(0.0, offset(0.001));
+        assertThat(alpha.calculateExpectedDisagreement()).isCloseTo(0.0, offset(0.001));
+        assertThat(alpha.calculateAgreement()).isCloseTo(0.0, offset(0.001));
+    }
+
+    /**
+     * A zero-length unit next to units of positive length must not mark the study as degenerate.
+     * The raters fully agree on the positive-length units, so the agreement is 1.0 via the regular
+     * formula (the expected disagreement is positive).
+     */
+    @Test
+    public void testZeroLengthUnitsMixedWithPositiveLengthUnits()
+    {
+        var study = new UnitizingAnnotationStudy(2, 15);
+        study.addUnit(0, 0, 0, "A");
+        study.addUnit(2, 5, 0, "A");
+        study.addUnit(2, 5, 1, "A");
+
+        var alpha = new KrippendorffAlphaUnitizingAgreement(study);
+        assertThat(alpha.calculateObservedDisagreement()).isCloseTo(0.0, offset(0.001));
+        assertThat(alpha.calculateExpectedDisagreement()).isGreaterThan(0.0);
+        assertThat(alpha.calculateAgreement()).isCloseTo(1.0, offset(0.001));
+    }
+
     @Test
     public void testDistanceMetric()
     {


### PR DESCRIPTION
**What's in the PR**
- Extract study information check into overridable `studyCarriesInformation()` method in `DisagreementMeasure`
- Override `studyCarriesInformation()` in `UnitizingAgreementMeasure` to exclude zero-length units as degenerate (issue #35)
- Add tests for zero-length-unit handling in `UnitizingAgreementTest`

**How to test manually**
* See issue description

**Automatic testing**
* [x] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
